### PR TITLE
Example of direct expression idea

### DIFF
--- a/PanoramicData.NCalcExtensions/DirectExpression.cs
+++ b/PanoramicData.NCalcExtensions/DirectExpression.cs
@@ -1,0 +1,60 @@
+
+namespace PanoramicData.NCalcExtensions;
+
+public class DirectExpression
+{
+	public DirectExpression()
+	{
+		return;
+	}
+
+	internal ExtendedExpression getExtendedExpression(string expressionString)
+	{
+		ExtendedExpression expression = new ExtendedExpression(expressionString);
+
+		if (expression.HasErrors())
+		{
+			throw new FormatException($"Could not evaluate expression: '{expressionString}' due to {expression.Error}.");
+		}
+        return expression;
+	}
+
+    internal object evaluate(ExtendedExpression expression)
+    {
+        return expression.Evaluate();
+    }
+
+    internal object evaluate(string expressionString)
+    {
+        ExtendedExpression expression = getExtendedExpression(expressionString);
+        return evaluate(expression);
+    }
+
+    internal string getExpressionString(string function, string[] args)
+    {
+        string formattedArgs = String.Join(", ", args);
+
+        return $"{function}({formattedArgs})";
+    }
+
+    public string Capitalize(string input)
+    {
+        string[] args = {input};
+        object result = evaluate(getExpressionString("capitalize", args));
+        return result.ToString();
+    }
+
+    public object Cast(object inputObject, Type desiredType)
+    {
+        string[] args = {inputObject.ToString(), $"'{desiredType}'"};
+        object result = evaluate(getExpressionString("cast", args));
+        return result;
+    }
+
+    public DateTime ChangeTimeZone(DateTime inputTime, string inputTimeZone, string outputTimeZone)
+    {
+        string[]args = {inputTime.ToString(), inputTimeZone, outputTimeZone};
+        object result = evaluate(getExpressionString("changeTimeZone", args));
+        return DateTime.Parse(result.ToString());
+    }
+}


### PR DESCRIPTION
Code completion and parameter typing for NCalc Expressions seems cool to me. I had an idea of doing these direct expressions that call ExtendedExpression behind the scenes. 

An alternative/additive approach to this would be using a dynamic approach using [TryInvokeMember](https://learn.microsoft.com/en-us/dotnet/api/system.dynamic.dynamicobject.tryinvokemember). 
This would not allow code completion or parameter typing, but it would look a lot cleaner in the editor and only need a single string input. 


Not tested whatsoever and not knowing what the code that uses these extensions looks like. 