### PR TITLE
Fixed wrong max comparison in GetMax method in Max.cs

### DIFF
--- a/PanoramicData.NCalcExtensions/Extensions/Max.cs
+++ b/PanoramicData.NCalcExtensions/Extensions/Max.cs
@@ -89,7 +89,7 @@ internal static class Max
 				null => 0,
 				_ => throw new FormatException($"Found unsupported type '{item?.GetType().Name}' when completing sum.")
 			};
-			if (thisOne < max)
+			if (thisOne > max)
 			{
 				max = thisOne;
 			}


### PR DESCRIPTION
The GetMax method was always returning 0 because the comparison statement was reversed