### PR TITLE
Update NCalcSync to version 5.11.0

### DIFF
--- a/PanoramicData.NCalcExtensions.Test/AllTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/AllTests.cs
@@ -10,7 +10,7 @@ public class AllTests : NCalcTest
 	[InlineData("7, 8, 9", false)]
 	public void All_LessThanFive_Succeeds(string stringList, bool allLessThanFive)
 		=> new ExtendedExpression($"all(list({stringList}), 'n', 'n < 5')")
-		.Evaluate()
+		.Evaluate(TestContext.Current.CancellationToken)
 		.Should()
 		.Be(allLessThanFive);
 
@@ -22,7 +22,7 @@ public class AllTests : NCalcTest
 	[InlineData("", true)]
 	public void All_Bools_Succeeds(string stringList, bool expectedResult)
 		=> new ExtendedExpression($"all(list({stringList}))")
-		.Evaluate()
+		.Evaluate(TestContext.Current.CancellationToken)
 		.Should()
 		.Be(expectedResult);
 
@@ -31,63 +31,63 @@ public class AllTests : NCalcTest
 	public void All_EmptyList_ReturnsTrue()
 	{
 		var expression = new ExtendedExpression("all(list(), 'n', 'n > 0')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void All_AllMatch_ReturnsTrue()
 	{
 		var expression = new ExtendedExpression("all(list(2, 4, 6, 8), 'n', 'n % 2 == 0')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void All_OneDoesNotMatch_ReturnsFalse()
 	{
 		var expression = new ExtendedExpression("all(list(2, 4, 5, 8), 'n', 'n % 2 == 0')");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	[Fact]
 	public void All_NoneMatch_ReturnsFalse()
 	{
 		var expression = new ExtendedExpression("all(list(1, 3, 5, 7), 'n', 'n % 2 == 0')");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	[Fact]
 	public void All_Strings_Works()
 	{
 		var expression = new ExtendedExpression("all(list('apple', 'apricot', 'avocado'), 's', 'startsWith(s, \"a\")')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void All_Strings_OneFails()
 	{
 		var expression = new ExtendedExpression("all(list('apple', 'banana', 'avocado'), 's', 'startsWith(s, \"a\")')");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	[Fact]
 	public void All_GreaterThan_Works()
 	{
 		var expression = new ExtendedExpression("all(list(10, 20, 30), 'n', 'n > 5')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void All_LessThanOrEqual_Works()
 	{
 		var expression = new ExtendedExpression("all(list(1, 2, 3, 4, 5), 'n', 'n <= 5')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void All_ComplexCondition_Works()
 	{
 		var expression = new ExtendedExpression("all(list(10, 20, 30), 'n', 'n >= 10 && n <= 30')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
@@ -95,42 +95,42 @@ public class AllTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("all(myList, 'n', 'n > 0')");
 		expression.Parameters["myList"] = new List<object> { 1, 2, 3, 4, 5 };
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void All_SingleItemTrue_ReturnsTrue()
 	{
 		var expression = new ExtendedExpression("all(list(5), 'n', 'n > 0')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void All_SingleItemFalse_ReturnsFalse()
 	{
 		var expression = new ExtendedExpression("all(list(-5), 'n', 'n > 0')");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	[Fact]
 	public void All_Doubles_Works()
 	{
 		var expression = new ExtendedExpression("all(list(1.5, 2.5, 3.5), 'n', 'n > 1.0')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void All_NegativeNumbers_Works()
 	{
 		var expression = new ExtendedExpression("all(list(-10, -20, -30), 'n', 'n < 0')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void All_WithNulls_HandlesNull()
 	{
 		var expression = new ExtendedExpression("all(list(1, null, 3), 'n', 'n != null')");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	// Error cases
@@ -138,7 +138,7 @@ public class AllTests : NCalcTest
 	public void All_NullList_ThrowsException()
 	{
 		var expression = new ExtendedExpression("all(null, 'n', 'n > 0')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>();
 	}
 
@@ -146,7 +146,7 @@ public class AllTests : NCalcTest
 	public void All_InvalidPredicate_ThrowsException()
 	{
 		var expression = new ExtendedExpression("all(list(1, 2, 3), null, 'n > 0')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>();
 	}
 
@@ -154,7 +154,7 @@ public class AllTests : NCalcTest
 	public void All_InvalidLambda_ThrowsException()
 	{
 		var expression = new ExtendedExpression("all(list(1, 2, 3), 'n', null)");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>();
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/AnyTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/AnyTests.cs
@@ -12,7 +12,7 @@ public class AnyTests : NCalcTest
 	{
 		var expression = new ExtendedExpression($"any(list({stringList}), 'n', 'n < 5')");
 
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().Be(expected);
 	}
@@ -21,7 +21,7 @@ public class AnyTests : NCalcTest
 	public void Any_Items_ReturnsTrue()
 	{
 		var expression = new ExtendedExpression($"any(list(1, 2, 3))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -29,7 +29,7 @@ public class AnyTests : NCalcTest
 	public void Any_NoItems_ReturnsFalse()
 	{
 		var expression = new ExtendedExpression($"any(list())");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(false);
 	}
 
@@ -43,70 +43,70 @@ public class AnyTests : NCalcTest
 	[InlineData("1, 2")]
 	[InlineData("1, 2, 3, 4")]
 	public void Any_BadParameters_ThrowsException(string parametersString)
-		=> new ExtendedExpression($"any({parametersString})").Invoking(x => x.Evaluate()).Should().ThrowExactly<FormatException>();
+		=> new ExtendedExpression($"any({parametersString})").Invoking(x => x.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>();
 
 	// Additional comprehensive tests
 	[Fact]
 	public void Any_EmptyList_ReturnsFalse()
 	{
 		var expression = new ExtendedExpression("any(list(), 'n', 'n > 0')");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	[Fact]
 	public void Any_OneMatches_ReturnsTrue()
 	{
 		var expression = new ExtendedExpression("any(list(1, 3, 5, 6), 'n', 'n % 2 == 0')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void Any_AllMatch_ReturnsTrue()
 	{
 		var expression = new ExtendedExpression("any(list(2, 4, 6, 8), 'n', 'n % 2 == 0')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void Any_NoneMatch_ReturnsFalse()
 	{
 		var expression = new ExtendedExpression("any(list(1, 3, 5, 7), 'n', 'n % 2 == 0')");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	[Fact]
 	public void Any_Strings_Works()
 	{
 		var expression = new ExtendedExpression("any(list('cat', 'dog', 'bird'), 's', 'startsWith(s, \"d\")')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void Any_Strings_NoneMatch()
 	{
 		var expression = new ExtendedExpression("any(list('cat', 'rat', 'bat'), 's', 'startsWith(s, \"d\")')");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	[Fact]
 	public void Any_GreaterThan_Works()
 	{
 		var expression = new ExtendedExpression("any(list(1, 2, 10), 'n', 'n > 5')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void Any_LessThanOrEqual_Works()
 	{
 		var expression = new ExtendedExpression("any(list(10, 20, 5), 'n', 'n <= 5')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void Any_ComplexCondition_Works()
 	{
 		var expression = new ExtendedExpression("any(list(5, 15, 25), 'n', 'n >= 10 && n <= 20')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
@@ -114,49 +114,49 @@ public class AnyTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("any(myList, 'n', 'n < 0')");
 		expression.Parameters["myList"] = new List<object> { 1, 2, -3, 4, 5 };
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void Any_SingleItemTrue_ReturnsTrue()
 	{
 		var expression = new ExtendedExpression("any(list(5), 'n', 'n > 0')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void Any_SingleItemFalse_ReturnsFalse()
 	{
 		var expression = new ExtendedExpression("any(list(-5), 'n', 'n > 0')");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	[Fact]
 	public void Any_Doubles_Works()
 	{
 		var expression = new ExtendedExpression("any(list(1.1, 1.2, 2.5), 'n', 'n > 2.0')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void Any_NegativeNumbers_Works()
 	{
 		var expression = new ExtendedExpression("any(list(10, 20, -5), 'n', 'n < 0')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void Any_WithNulls_HandlesNull()
 	{
 		var expression = new ExtendedExpression("any(list(1, null, 3), 'n', 'n == null')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void Any_Booleans_True()
 	{
 		var expression = new ExtendedExpression("any(list(false, false, true))");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
@@ -164,6 +164,6 @@ public class AnyTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("any(list(false, false, false))");
 		// Any with no predicate just checks if list has items
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/BangTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/BangTests.cs
@@ -7,7 +7,7 @@ public class BangTests : NCalcTest
 	{
 		const string expression = "!(1 == 2)";
 		var e = new ExtendedExpression(expression);
-		var result = e.Evaluate();
+		var result = e.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/CanEvaluateTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/CanEvaluateTests.cs
@@ -10,7 +10,7 @@ public class CanEvaluateTests
 	{
 		var expression = new ExtendedExpression($"canEvaluate({value})");
 
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().Be(expected);
 	}

--- a/PanoramicData.NCalcExtensions.Test/CapitalizeTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/CapitalizeTests.cs
@@ -12,7 +12,7 @@ public class CapitalizeTests : NCalcTest
 	{
 		var expression = new ExtendedExpression($"capitalize('{input}')");
 
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().Be(expected);
 	}
@@ -21,14 +21,14 @@ public class CapitalizeTests : NCalcTest
 	public void Capitalize_NullParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("capitalize(null)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>();
 	}
 
 	[Fact]
 	public void Capitalize_NonStringParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("capitalize(123)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>();
 	}
 }
 

--- a/PanoramicData.NCalcExtensions.Test/CastTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/CastTests.cs
@@ -16,63 +16,63 @@ public class CastTests
 	public void Cast_CommonTypes_MatchesExpectedValue(string input, string type, object expected)
 	{
 		var expression = new ExtendedExpression($"cast({input},'{type}')");
-		expression.Evaluate().Should().Be(expected);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(expected);
 	}
 
 	[Fact]
 	public void Cast_ToDecimal_Succeeds()
 	{
 		var expression = new ExtendedExpression("cast(1, 'System.Decimal')");
-		expression.Evaluate().Should().Be(1.0m);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(1.0m);
 	}
 
 	[Fact]
 	public void Cast_ToUInt32_Succeeds()
 	{
 		var expression = new ExtendedExpression("cast(42, 'System.UInt32')");
-		expression.Evaluate().Should().Be(42u);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(42u);
 	}
 
 	[Fact]
 	public void Cast_ToUInt64_Succeeds()
 	{
 		var expression = new ExtendedExpression("cast(42, 'System.UInt64')");
-		expression.Evaluate().Should().Be(42UL);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(42UL);
 	}
 
 	[Fact]
 	public void Cast_ToInt16_Succeeds()
 	{
 		var expression = new ExtendedExpression("cast(42, 'System.Int16')");
-		expression.Evaluate().Should().Be((short)42);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((short)42);
 	}
 
 	[Fact]
 	public void Cast_ToByte_Succeeds()
 	{
 		var expression = new ExtendedExpression("cast(42, 'System.Byte')");
-		expression.Evaluate().Should().Be((byte)42);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((byte)42);
 	}
 
 	[Fact]
 	public void Cast_ToSByte_Succeeds()
 	{
 		var expression = new ExtendedExpression("cast(-42, 'System.SByte')");
-		expression.Evaluate().Should().Be((sbyte)-42);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((sbyte)-42);
 	}
 
 	[Fact]
 	public void Cast_ToUInt16_Succeeds()
 	{
 		var expression = new ExtendedExpression("cast(42, 'System.UInt16')");
-		expression.Evaluate().Should().Be((ushort)42);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((ushort)42);
 	}
 
 	[Fact]
 	public void Cast_ToFloat_Succeeds()
 	{
 		var expression = new ExtendedExpression("cast(42, 'System.Single')");
-		var result = (float)expression.Evaluate()!;
+		var result = (float)expression.Evaluate(TestContext.Current.CancellationToken)!;
 		result.Should().BeApproximately(42.0f, 0.01f);
 	}
 
@@ -83,28 +83,28 @@ public class CastTests
 	public void Cast_ToBool_ReturnsExpected(string input, bool expected)
 	{
 		var expression = new ExtendedExpression($"cast({input}, 'System.Boolean')");
-		expression.Evaluate().Should().Be(expected);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(expected);
 	}
 
 	[Fact]
 	public void Cast_StringToDouble_Succeeds()
 	{
 		var expression = new ExtendedExpression("cast('3.14', 'System.Double')");
-		expression.Evaluate().Should().Be(3.14);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(3.14);
 	}
 
 	[Fact]
 	public void Cast_MaxValue_Int_Succeeds()
 	{
 		var expression = new ExtendedExpression("cast(2147483647, 'System.Int32')");
-		expression.Evaluate().Should().Be(int.MaxValue);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(int.MaxValue);
 	}
 
 	[Fact]
 	public void Cast_MinValue_Int_Succeeds()
 	{
 		var expression = new ExtendedExpression("cast(-2147483648, 'System.Int32')");
-		expression.Evaluate().Should().Be(int.MinValue);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(int.MinValue);
 	}
 
 	[Fact]
@@ -112,7 +112,7 @@ public class CastTests
 	{
 		var expression = new ExtendedExpression("cast(myValue, 'System.String')");
 		expression.Parameters["myValue"] = 42;
-		expression.Evaluate().Should().Be("42");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("42");
 	}
 
 	[Fact]
@@ -120,34 +120,34 @@ public class CastTests
 	{
 		var expression = new ExtendedExpression("cast(42, myType)");
 		expression.Parameters["myType"] = "System.String";
-		expression.Evaluate().Should().Be("42");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("42");
 	}
 
 	[Theory]
 	[InlineData("cast(42, 'UnsupportedType')")]
 	[InlineData("cast('notanumber', 'System.Int32')")]
 	public void Cast_InvalidInput_ThrowsException(string expression) => new ExtendedExpression(expression)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<Exception>();
 
 	[Fact]
 	public void Cast_ChainedCasts_Works()
 	{
 		var expression = new ExtendedExpression("cast(cast(42.7, 'System.Int32'), 'System.String')");
-		expression.Evaluate().Should().Be("43");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("43");
 	}
 
 	[Fact]
 	public void Cast_InArithmetic_Works()
 	{
 		var expression = new ExtendedExpression("cast(5, 'System.Double') / 2");
-		expression.Evaluate().Should().Be(2.5);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(2.5);
 	}
 
 	[Fact]
 	public void Cast_InComparison_Works()
 	{
 		var expression = new ExtendedExpression("cast('42', 'System.Int32') > 40");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/ChangeTimeZoneTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/ChangeTimeZoneTests.cs
@@ -8,7 +8,7 @@ public class ChangeTimeZonesTests : NCalcTest
 		const string parameterName = "theDateTimeUtc";
 		var expression = new ExtendedExpression($"changeTimeZone({parameterName}, 'UTC', 'Eastern Standard Time')");
 		expression.Parameters[parameterName] = new DateTime(2020, 03, 13, 16, 00, 00);
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(new DateTime(2020, 03, 13, 12, 00, 00));
 	}
 
@@ -18,7 +18,7 @@ public class ChangeTimeZonesTests : NCalcTest
 		const string parameterName = "theDateTimeUtc";
 		var expression = new ExtendedExpression($"changeTimeZone({parameterName}, 'Eastern Standard Time', 'UTC')");
 		expression.Parameters[parameterName] = new DateTime(2020, 03, 13, 12, 00, 00);
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(new DateTime(2020, 03, 13, 16, 00, 00));
 	}
 
@@ -26,7 +26,7 @@ public class ChangeTimeZonesTests : NCalcTest
 	public void ChangeTimeZone_WrongParameterCount_ThrowsException()
 	{
 		var expression = new ExtendedExpression("changeTimeZone(now(), 'UTC')");
-		expression.Invoking(e => e.Evaluate()).Should().Throw<ArgumentException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().Throw<ArgumentException>()
 			.WithMessage("*Expected 3 arguments*");
 	}
 
@@ -34,7 +34,7 @@ public class ChangeTimeZonesTests : NCalcTest
 	public void ChangeTimeZone_NonDateTimeFirstParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("changeTimeZone('not a date', 'UTC', 'EST')");
-		expression.Invoking(e => e.Evaluate()).Should().Throw<ArgumentException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().Throw<ArgumentException>()
 			.WithMessage("*parameter 1 should be a DateTime*");
 	}
 
@@ -42,7 +42,7 @@ public class ChangeTimeZonesTests : NCalcTest
 	public void ChangeTimeZone_NonStringSecondParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("changeTimeZone(now(), 123, 'EST')");
-		expression.Invoking(e => e.Evaluate()).Should().Throw<ArgumentException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().Throw<ArgumentException>()
 			.WithMessage("*parameter 2 should be a string*");
 	}
 
@@ -50,7 +50,7 @@ public class ChangeTimeZonesTests : NCalcTest
 	public void ChangeTimeZone_NonStringThirdParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("changeTimeZone(now(), 'UTC', 456)");
-		expression.Invoking(e => e.Evaluate()).Should().Throw<ArgumentException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().Throw<ArgumentException>()
 			.WithMessage("*parameter 3 should be a string*");
 	}
 
@@ -61,7 +61,7 @@ public class ChangeTimeZonesTests : NCalcTest
 		var dateTime = new DateTime(2023, 6, 15, 12, 0, 0);
 		var expression = new ExtendedExpression("changeTimeZone(dt, 'UTC', 'UTC')");
 		expression.Parameters["dt"] = dateTime;
-		expression.Evaluate().Should().Be(dateTime);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(dateTime);
 	}
 
 	[Fact]
@@ -69,7 +69,7 @@ public class ChangeTimeZonesTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("changeTimeZone(dt, 'Pacific Standard Time', 'Eastern Standard Time')");
 		expression.Parameters["dt"] = new DateTime(2023, 1, 15, 10, 0, 0);
-		var result = expression.Evaluate() as DateTime?;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as DateTime?;
 		result.Should().NotBeNull();
 		// PST is UTC-8, EST is UTC-5, so +3 hours
 		result.Should().Be(new DateTime(2023, 1, 15, 13, 0, 0));
@@ -80,7 +80,7 @@ public class ChangeTimeZonesTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("changeTimeZone(dt, 'Tokyo Standard Time', 'GMT Standard Time')");
 		expression.Parameters["dt"] = new DateTime(2023, 1, 15, 18, 0, 0);
-		var result = expression.Evaluate() as DateTime?;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as DateTime?;
 		result.Should().NotBeNull();
 	}
 
@@ -88,21 +88,21 @@ public class ChangeTimeZonesTests : NCalcTest
 	public void ChangeTimeZone_InvalidSourceTimezone_ThrowsException()
 	{
 		var expression = new ExtendedExpression("changeTimeZone(now(), 'Invalid/Timezone', 'UTC')");
-		expression.Invoking(e => e.Evaluate()).Should().Throw<Exception>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().Throw<Exception>();
 	}
 
 	[Fact]
 	public void ChangeTimeZone_InvalidTargetTimezone_ThrowsException()
 	{
 		var expression = new ExtendedExpression("changeTimeZone(now(), 'UTC', 'Invalid/Timezone')");
-		expression.Invoking(e => e.Evaluate()).Should().Throw<Exception>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().Throw<Exception>();
 	}
 
 	[Fact]
 	public void ChangeTimeZone_WithNow_Works()
 	{
 		var expression = new ExtendedExpression("changeTimeZone(now(), 'UTC', 'Eastern Standard Time')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<DateTime>();
 	}
 
@@ -111,7 +111,7 @@ public class ChangeTimeZonesTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("changeTimeZone(dt, 'UTC', 'Eastern Standard Time')");
 		expression.Parameters["dt"] = DateTime.MinValue;
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<DateTime>();
 	}
 
@@ -120,7 +120,7 @@ public class ChangeTimeZonesTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("changeTimeZone(dt, 'UTC', 'Eastern Standard Time')");
 		expression.Parameters["dt"] = DateTime.MaxValue;
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<DateTime>();
 	}
 
@@ -128,42 +128,42 @@ public class ChangeTimeZonesTests : NCalcTest
 	public void ChangeTimeZone_NoParameters_ThrowsException()
 	{
 		var expression = new ExtendedExpression("changeTimeZone()");
-		expression.Invoking(e => e.Evaluate()).Should().Throw<ArgumentException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().Throw<ArgumentException>();
 	}
 
 	[Fact]
 	public void ChangeTimeZone_OneParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("changeTimeZone(now())");
-		expression.Invoking(e => e.Evaluate()).Should().Throw<ArgumentException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().Throw<ArgumentException>();
 	}
 
 	[Fact]
 	public void ChangeTimeZone_FourParameters_ThrowsException()
 	{
 		var expression = new ExtendedExpression("changeTimeZone(now(), 'UTC', 'EST', 'extra')");
-		expression.Invoking(e => e.Evaluate()).Should().Throw<ArgumentException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().Throw<ArgumentException>();
 	}
 
 	[Fact]
 	public void ChangeTimeZone_NullDateTime_ThrowsException()
 	{
 		var expression = new ExtendedExpression("changeTimeZone(null, 'UTC', 'EST')");
-		expression.Invoking(e => e.Evaluate()).Should().Throw<ArgumentException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().Throw<ArgumentException>();
 	}
 
 	[Fact]
 	public void ChangeTimeZone_NullSourceTimezone_ThrowsException()
 	{
 		var expression = new ExtendedExpression("changeTimeZone(now(), null, 'EST')");
-		expression.Invoking(e => e.Evaluate()).Should().Throw<ArgumentException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().Throw<ArgumentException>();
 	}
 
 	[Fact]
 	public void ChangeTimeZone_NullTargetTimezone_ThrowsException()
 	{
 		var expression = new ExtendedExpression("changeTimeZone(now(), 'UTC', null)");
-		expression.Invoking(e => e.Evaluate()).Should().Throw<ArgumentException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().Throw<ArgumentException>();
 	}
 
 	[Fact]
@@ -172,7 +172,7 @@ public class ChangeTimeZonesTests : NCalcTest
 		// During daylight saving time
 		var expression = new ExtendedExpression("changeTimeZone(dt, 'UTC', 'Eastern Standard Time')");
 		expression.Parameters["dt"] = new DateTime(2023, 7, 15, 12, 0, 0);
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<DateTime>();
 	}
 
@@ -181,7 +181,7 @@ public class ChangeTimeZonesTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("format(changeTimeZone(dt, 'UTC', 'Eastern Standard Time'), 'yyyy-MM-dd HH:mm')");
 		expression.Parameters["dt"] = new DateTime(2023, 1, 15, 12, 0, 0);
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().NotBeNullOrEmpty();
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/ConcatTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/ConcatTests.cs
@@ -21,7 +21,7 @@ public class ConcatTests
 	[InlineData("concat(42)", new object[] { 42 })]
 	public void Concat_VariousScenarios_ReturnsExpected(string expression, object[] expected)
 	{
-		var result = new ExtendedExpression(expression).Evaluate();
+		var result = new ExtendedExpression(expression).Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<List<object?>>();
 		result.Should().BeEquivalentTo(expected, options => options.WithStrictOrdering());
 	}
@@ -30,14 +30,14 @@ public class ConcatTests
 	public void Concat_Strings_Works()
 	{
 		var expression = new ExtendedExpression("concat(list('a', 'b'), list('c', 'd'))");
-		expression.Evaluate().Should().BeEquivalentTo(new List<object> { "a", "b", "c", "d" }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<object> { "a", "b", "c", "d" }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void Concat_MixedTypes_Works()
 	{
 		var expression = new ExtendedExpression("concat(list(1, 'two'), list(3.0, true))");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(4);
 	}
@@ -46,7 +46,7 @@ public class ConcatTests
 	public void Concat_WithNulls_PreservesNulls()
 	{
 		var expression = new ExtendedExpression("concat(list(1, null), list(null, 2))");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(4);
 		result![1].Should().BeNull();
@@ -59,7 +59,7 @@ public class ConcatTests
 		var expression = new ExtendedExpression("concat(myList1, myList2)");
 		expression.Parameters["myList1"] = new List<int> { 1, 2 };
 		expression.Parameters["myList2"] = new List<int> { 3, 4 };
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(4);
 	}
@@ -70,7 +70,7 @@ public class ConcatTests
 		var expression = new ExtendedExpression("concat(array1, array2)");
 		expression.Parameters["array1"] = new[] { 1, 2 };
 		expression.Parameters["array2"] = new[] { 3, 4 };
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(4);
 	}
@@ -79,20 +79,20 @@ public class ConcatTests
 	public void Concat_Chained_Works()
 	{
 		var expression = new ExtendedExpression("concat(concat(list(1), list(2)), list(3))");
-		expression.Evaluate().Should().BeEquivalentTo(new List<object> { 1, 2, 3 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<object> { 1, 2, 3 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void Concat_WithSelect_Works()
 	{
 		var expression = new ExtendedExpression("concat(select(list(1, 2), 'n', 'n * 2'), list(5, 6))");
-		expression.Evaluate().Should().BeEquivalentTo(new List<object> { 2, 4, 5, 6 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<object> { 2, 4, 5, 6 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void Concat_BooleanValues_Works()
 	{
 		var expression = new ExtendedExpression("concat(list(true, false), list(true))");
-		expression.Evaluate().Should().BeEquivalentTo(new List<object> { true, false, true }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<object> { true, false, true }, options => options.WithStrictOrdering());
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/ContainsTest.cs
+++ b/PanoramicData.NCalcExtensions.Test/ContainsTest.cs
@@ -10,7 +10,7 @@ public class ContainsTest
 	{
 		var expression = new ExtendedExpression(expressionText);
 
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().Be(expected);
 	}

--- a/PanoramicData.NCalcExtensions.Test/ContainsTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/ContainsTests.cs
@@ -11,7 +11,7 @@ public class ContainsTests
 	public void Contains_Succeeds(string haystack, string needle, bool expectedResult)
 	{
 		var expression = new ExtendedExpression($"contains({haystack}, {needle})");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<bool>();
 		result.Should().Be(expectedResult);
 	}
@@ -20,20 +20,20 @@ public class ContainsTests
 	public void Contains_NullHaystack_ThrowsException()
 	{
 		var expression = new ExtendedExpression("contains(null, 'needle')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>();
 	}
 
 	[Fact]
 	public void Contains_NullNeedle_ThrowsException()
 	{
 		var expression = new ExtendedExpression("contains('haystack', null)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>();
 	}
 
 	[Fact]
 	public void Contains_NonStringParameters_ThrowsException()
 	{
 		var expression = new ExtendedExpression("contains(123, 456)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>();
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/ConvertTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/ConvertTests.cs
@@ -16,7 +16,7 @@ public class ConvertTests
 		object? expectedResult
 	)
 		=> new ExtendedExpression($"convert({firstParameter}, {secondParameter})")
-		.Evaluate()
+		.Evaluate(TestContext.Current.CancellationToken)
 		.Should()
 		.Be(expectedResult);
 
@@ -27,7 +27,7 @@ public class ConvertTests
 	[InlineData("1, 1, 1, 1")]
 	public void IncorrectParameterCount_Throws(string parameters) =>
 		new ExtendedExpression($"convert({parameters})")
-		.Invoking(e => e.Evaluate())
+		.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 		.Should()
 		.Throw<FormatException>()
 		.WithMessage($"{ExtensionFunction.Convert}() requires two parameters.");

--- a/PanoramicData.NCalcExtensions.Test/CountByJsonDocumentTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/CountByJsonDocumentTests.cs
@@ -11,7 +11,7 @@ public class CountByJsonDocumentTests
 	{
 		var expression = new ExtendedExpression(expressionText);
 
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		// CountBy still returns JObject, but we verify it works with JsonDocument operations
 		result.Should().BeOfType<JObject>();
 		result.Should().NotBeNull();
@@ -29,7 +29,7 @@ public class CountByJsonDocumentTests
 		var jsonDoc = JsonDocument.Parse("[1, 2, 2, 3, 3, 3, 4]");
 		var expression = new ExtendedExpression("toString(typeOf(source))");
 		expression.Parameters["source"] = jsonDoc;
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be("JsonDocument");
 	}
 
@@ -38,7 +38,7 @@ public class CountByJsonDocumentTests
 	{
 		// Test property access on countBy result using JsonDocument-style operations
 		var expression = new ExtendedExpression("countBy(list(1, 2, 2, 3, 3, 3, 4), 'n', 'toString(n)')");
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		
 		result.Should().NotBeNull();
 		result!["1"].Should().NotBeNull();

--- a/PanoramicData.NCalcExtensions.Test/CountByTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/CountByTests.cs
@@ -11,7 +11,7 @@ public class CountByTests
 	{
 		var expression = new ExtendedExpression(expressionText);
 
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<JObject>();
 		result.Should().NotBeNull();
 		result.ToString()!
@@ -26,7 +26,7 @@ public class CountByTests
 	public void CountBy_EmptyList_ReturnsEmptyJObject()
 	{
 		var expression = new ExtendedExpression("countBy(list(), 'n', 'toString(n)')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<JObject>();
 		((JObject)result).Count.Should().Be(0);
 	}
@@ -36,7 +36,7 @@ public class CountByTests
 	public void CountBy_AllSameValues_ReturnsSingleGroup()
 	{
 		var expression = new ExtendedExpression("countBy(list(1, 1, 1, 1), 'n', 'toString(n)')");
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().NotBeNull();
 		result!["1"]!.Value<int>().Should().Be(4);
 	}
@@ -46,7 +46,7 @@ public class CountByTests
 	public void CountBy_Strings_GroupsCorrectly()
 	{
 		var expression = new ExtendedExpression("countBy(list('apple', 'banana', 'apple', 'cherry', 'banana', 'apple'), 'n', 'n')");
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().NotBeNull();
 		result!["apple"]!.Value<int>().Should().Be(3);
 		result["banana"]!.Value<int>().Should().Be(2);
@@ -58,7 +58,7 @@ public class CountByTests
 	public void CountBy_ComplexLambda_GroupsCorrectly()
 	{
 		var expression = new ExtendedExpression("countBy(list(1, 2, 3, 4, 5, 6), 'n', 'if(n % 2 == 0, \"even\", \"odd\")')");
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().NotBeNull();
 		result!["even"]!.Value<int>().Should().Be(3);
 		result["odd"]!.Value<int>().Should().Be(3);
@@ -69,7 +69,7 @@ public class CountByTests
 	public void CountBy_ListWithNull_HandlesNullGroup()
 	{
 		var expression = new ExtendedExpression("countBy(list(1, null, 2, null, 3), 'n', 'if(isNull(n), \"null\", toString(n))')");
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().NotBeNull();
 		result!["null"]!.Value<int>().Should().Be(2);
 		result["1"]!.Value<int>().Should().Be(1);
@@ -80,7 +80,7 @@ public class CountByTests
 	public void CountBy_GroupByLength_Works()
 	{
 		var expression = new ExtendedExpression("countBy(list('a', 'bb', 'ccc', 'dd', 'e'), 'n', 'toString(length(n))')");
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().NotBeNull();
 		result!["1"]!.Value<int>().Should().Be(2);
 		result["2"]!.Value<int>().Should().Be(2);
@@ -92,7 +92,7 @@ public class CountByTests
 	public void CountBy_NumberRanges_GroupsCorrectly()
 	{
 		var expression = new ExtendedExpression("countBy(list(1, 5, 10, 15, 20, 25, 30), 'n', 'if(n < 10, \"small\", if(n < 20, \"medium\", \"large\"))')");
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().NotBeNull();
 		result!["small"]!.Value<int>().Should().Be(2);
 		result["medium"]!.Value<int>().Should().Be(2);
@@ -104,7 +104,7 @@ public class CountByTests
 	public void CountBy_SingleItem_ReturnsSingleGroup()
 	{
 		var expression = new ExtendedExpression("countBy(list(42), 'n', 'toString(n)')");
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().NotBeNull();
 		result!["42"]!.Value<int>().Should().Be(1);
 	}
@@ -114,7 +114,7 @@ public class CountByTests
 	public void CountBy_BooleanGroups_Works()
 	{
 		var expression = new ExtendedExpression("countBy(list(1, 2, 3, 4, 5), 'n', 'toString(n > 3)')");
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().NotBeNull();
 		result!["False"]!.Value<int>().Should().Be(3);
 		result["True"]!.Value<int>().Should().Be(2);
@@ -125,7 +125,7 @@ public class CountByTests
 	public void CountBy_ReusedKeys_Accumulates()
 	{
 		var expression = new ExtendedExpression("countBy(list(1, 11, 2, 12, 3, 13), 'n', 'toString(n % 10)')");
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().NotBeNull();
 		result!["1"]!.Value<int>().Should().Be(2);
 		result["2"]!.Value<int>().Should().Be(2);
@@ -137,7 +137,7 @@ public class CountByTests
 	public void CountBy_NullList_ThrowsException()
 	{
 		var expression = new ExtendedExpression("countBy(null, 'n', 'toString(n)')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*requires IEnumerable*");
 	}
@@ -146,7 +146,7 @@ public class CountByTests
 	public void CountBy_NullPredicate_ThrowsException()
 	{
 		var expression = new ExtendedExpression("countBy(list(1, 2, 3), null, 'toString(n)')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*Second*parameter must be a string*");
 	}
@@ -155,7 +155,7 @@ public class CountByTests
 	public void CountBy_NullLambda_ThrowsException()
 	{
 		var expression = new ExtendedExpression("countBy(list(1, 2, 3), 'n', null)");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*Third*parameter must be a string*");
 	}
@@ -164,7 +164,7 @@ public class CountByTests
 	public void CountBy_LambdaReturnsNonString_ThrowsException()
 	{
 		var expression = new ExtendedExpression("countBy(list(1, 2, 3), 'n', 'n')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*should evaluate to a string*");
 	}
@@ -173,7 +173,7 @@ public class CountByTests
 	public void CountBy_LambdaReturnsNull_ThrowsException()
 	{
 		var expression = new ExtendedExpression("countBy(list(1, null, 3), 'n', 'n')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*should evaluate to a string*");
 	}
@@ -186,7 +186,7 @@ public class CountByTests
 		expression.Parameters["myList"] = new List<int> { 1, 2, 2, 3, 3, 3 };
 		expression.Parameters["myPredicate"] = "n";
 		expression.Parameters["myLambda"] = "toString(n)";
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().NotBeNull();
 		result!["1"]!.Value<int>().Should().Be(1);
 		result["2"]!.Value<int>().Should().Be(2);
@@ -199,7 +199,7 @@ public class CountByTests
 	{
 		var expression = new ExtendedExpression("countBy(myList, 'n', 'toString(n)')");
 		expression.Parameters["myList"] = new List<int> { 1, 2, 2, 3, 3, 3 };
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().NotBeNull();
 		result!["1"]!.Value<int>().Should().Be(1);
 		result["2"]!.Value<int>().Should().Be(2);
@@ -212,7 +212,7 @@ public class CountByTests
 	{
 		var expression = new ExtendedExpression("countBy(myList, 's', 's')");
 		expression.Parameters["myList"] = new List<string> { "apple", "banana", "apple" };
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().NotBeNull();
 		result!["apple"]!.Value<int>().Should().Be(2);
 		result["banana"]!.Value<int>().Should().Be(1);
@@ -224,7 +224,7 @@ public class CountByTests
 	{
 		var expression = new ExtendedExpression("countBy(myArray, 'n', 'toString(n)')");
 		expression.Parameters["myArray"] = new int[] { 1, 2, 2, 3 };
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().NotBeNull();
 		result!["1"]!.Value<int>().Should().Be(1);
 		result["2"]!.Value<int>().Should().Be(2);
@@ -235,7 +235,7 @@ public class CountByTests
 	public void CountBy_CaseSensitive_TreatsAsDifferent()
 	{
 		var expression = new ExtendedExpression("countBy(list('Apple', 'apple', 'APPLE'), 'n', 'n')");
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().NotBeNull();
 		result!.Count.Should().Be(3); // All three are different keys
 	}
@@ -245,7 +245,7 @@ public class CountByTests
 	public void CountBy_SpecialCharactersInKeys_Works()
 	{
 		var expression = new ExtendedExpression("countBy(list('a-b', 'a-b', 'c_d'), 'n', 'n')");
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().NotBeNull();
 		result!["a-b"]!.Value<int>().Should().Be(2);
 		result["c_d"]!.Value<int>().Should().Be(1);

--- a/PanoramicData.NCalcExtensions.Test/CountTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/CountTests.cs
@@ -15,7 +15,7 @@ public class CountTests
 	public void Count_VariousInputs_ReturnsExpected(string input, int expected)
 	{
 		var expression = new ExtendedExpression($"count({input})");
-		expression.Evaluate().Should().Be(expected);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(expected);
 	}
 
 	[Fact]
@@ -23,7 +23,7 @@ public class CountTests
 	{
 		var expression = new ExtendedExpression($"count(x)");
 		expression.Parameters.Add("x", _stringList);
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(_stringList.Count);
 	}
 
@@ -31,7 +31,7 @@ public class CountTests
 	public void Count_WithLambda_ReturnsExpectedResult()
 	{
 		var expression = new ExtendedExpression($"count(list(1,2,3), 'n', 'n < 3')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(2);
 	}
 
@@ -40,7 +40,7 @@ public class CountTests
 	{
 		var expression = new ExtendedExpression($"count(x)");
 		expression.Parameters.Add("x", _stringList.AsEnumerable());
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(_stringList.Count);
 	}
 
@@ -49,7 +49,7 @@ public class CountTests
 	{
 		var expression = new ExtendedExpression($"count(x)");
 		expression.Parameters.Add("x", _stringList.AsReadOnly());
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(_stringList.Count);
 	}
 
@@ -58,7 +58,7 @@ public class CountTests
 	{
 		var expression = new ExtendedExpression($"count(x)");
 		expression.Parameters.Add("x", JArray.FromObject(_stringList));
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(_stringList.Count);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/DateAddTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/DateAddTests.cs
@@ -26,7 +26,7 @@ public class DateAddTests : NCalcTest
 		expression.Parameters.Add("quantity", quantity);
 		expression.Parameters.Add("initialDateTime", initialDateTime);
 
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<DateTime>();
 		result.Should().Be(expectedDateTime);
 	}
@@ -45,7 +45,7 @@ public class DateAddTests : NCalcTest
 		expression.Parameters.Add("quantity", quantity);
 		expression.Parameters.Add("initialDateTime", initialDateTime);
 
-		var action = expression.Evaluate;
+		var action = () => expression.Evaluate(TestContext.Current.CancellationToken);
 		action.Should().Throw<FormatException>();
 	}
 
@@ -61,7 +61,7 @@ public class DateAddTests : NCalcTest
 		expression.Parameters.Add("quantity", quantity);
 		expression.Parameters.Add("initialDateTime", initialDateTime);
 
-		var action = expression.Evaluate;
+		var action = () => expression.Evaluate(TestContext.Current.CancellationToken);
 		action.Should().Throw<ArgumentOutOfRangeException>();
 	}
 
@@ -77,7 +77,7 @@ public class DateAddTests : NCalcTest
 		expression.Parameters.Add("quantity", quantity);
 		expression.Parameters.Add("initialDateTime", initialDateTime);
 
-		var action = expression.Evaluate;
+		var action = () => expression.Evaluate(TestContext.Current.CancellationToken);
 		action.Should().Throw<FormatException>();
 	}
 
@@ -93,7 +93,7 @@ public class DateAddTests : NCalcTest
 		expression.Parameters.Add("quantity", quantity);
 		expression.Parameters.Add("initialDateTime", initialDateTime);
 
-		var action = expression.Evaluate;
+		var action = () => expression.Evaluate(TestContext.Current.CancellationToken);
 		action.Should().Throw<FormatException>();
 	}
 
@@ -109,7 +109,7 @@ public class DateAddTests : NCalcTest
 		expression.Parameters.Add("quantity", quantity);
 		expression.Parameters.Add("initialDateTime", initialDateTime);
 
-		var action = expression.Evaluate;
+		var action = () => expression.Evaluate(TestContext.Current.CancellationToken);
 		action.Should().Throw<FormatException>();
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/DateTimeAsEpochMsTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/DateTimeAsEpochMsTests.cs
@@ -15,7 +15,7 @@ public class DateTimeAsEpochMsTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("1 > dateTimeAsEpochMs([connectMagic.systemItem.sys_updated_on], 'yyyy-MM-dd HH:mm:ss')");
 		expression.Parameters.Add("connectMagic.systemItem.sys_updated_on", "2018-01-01 01:01:01");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(false);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/DateTimeAsEpochTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/DateTimeAsEpochTests.cs
@@ -15,7 +15,7 @@ public class DateTimeAsEpochTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("1 > dateTimeAsEpoch([connectMagic.systemItem.sys_updated_on], 'yyyy-MM-dd HH:mm:ss')");
 		expression.Parameters.Add("connectMagic.systemItem.sys_updated_on", "2018-01-01 01:01:01");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(false);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/DateTimeIsInFutureTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/DateTimeIsInFutureTests.cs
@@ -7,7 +7,7 @@ public class DateTimeIsInFutureTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("dateTimeIsInFuture(valueUnderTest)");
 		expression.Parameters.Add("valueUnderTest", DateTime.UtcNow.AddMilliseconds(2000));
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<bool>();
 
 		((bool)result).Should().BeTrue();
@@ -18,7 +18,7 @@ public class DateTimeIsInFutureTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("dateTimeIsInFuture(valueUnderTest)");
 		expression.Parameters.Add("valueUnderTest", DateTime.UtcNow.AddMilliseconds(-2000));
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<bool>();
 
 		((bool)result).Should().BeFalse();
@@ -30,7 +30,7 @@ public class DateTimeIsInFutureTests : NCalcTest
 		// West Africa Time does not observe Daylight Saving, so its offset from UTC is constant
 		var expression = new ExtendedExpression("dateTimeIsInFuture(valueUnderTest, 'Africa/Luanda')");
 		expression.Parameters.Add("valueUnderTest", DateTime.UtcNow.AddHours(1).AddMilliseconds(2000));
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<bool>();
 
 		((bool)result).Should().BeTrue();
@@ -42,7 +42,7 @@ public class DateTimeIsInFutureTests : NCalcTest
 		// West Africa Time does not observe Daylight Saving, so its offset from UTC is constant
 		var expression = new ExtendedExpression("dateTimeIsInFuture(valueUnderTest, 'Africa/Luanda')");
 		expression.Parameters.Add("valueUnderTest", DateTime.UtcNow.AddHours(1).AddMilliseconds(-2000));
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<bool>();
 
 		((bool)result).Should().BeFalse();
@@ -53,7 +53,7 @@ public class DateTimeIsInFutureTests : NCalcTest
 	{
 		// West Africa Time does not observe Daylight Saving, so its offset from UTC is constant
 		var expression = new ExtendedExpression("dateTimeIsInFuture(now(), 'Africa/Luanda')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<bool>();
 
 		((bool)result).Should().BeFalse();
@@ -65,7 +65,7 @@ public class DateTimeIsInFutureTests : NCalcTest
 		// CET is always ahead of UTC, so UtcNow masquerading as CET is always in the past
 		var expression = new ExtendedExpression("dateTimeIsInFuture(valueUnderTest, 'Central European Standard Time')");
 		expression.Parameters.Add("valueUnderTest", DateTime.UtcNow);
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<bool>();
 
 		((bool)result).Should().BeFalse();
@@ -75,7 +75,7 @@ public class DateTimeIsInFutureTests : NCalcTest
 	public void Evaluate_1stJan2001_ReturnsFalse()
 	{
 		var expression = new ExtendedExpression("dateTimeIsInFuture(toDateTime('2001-01-01T00:00:00', 'yyyy-MM-ddTHH:mm:ss'))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<bool>();
 
 		((bool)result).Should().BeFalse();
@@ -85,7 +85,7 @@ public class DateTimeIsInFutureTests : NCalcTest
 	public void Evaluate_1stJan2201_ReturnsTrue()
 	{
 		var expression = new ExtendedExpression("dateTimeIsInFuture(toDateTime('2201-01-01T00:00:00', 'yyyy-MM-ddTHH:mm:ss'))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<bool>();
 
 		((bool)result).Should().BeTrue();
@@ -97,7 +97,7 @@ public class DateTimeIsInFutureTests : NCalcTest
 	[InlineData("dateTimeIsInFuture()")]
 	[InlineData("dateTimeIsInFuture(null)")]
 	public void DateTimeIsInFuture_InvalidParameters_ThrowsException(string expression) => new ExtendedExpression(expression)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>();
 
@@ -106,7 +106,7 @@ public class DateTimeIsInFutureTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("dateTimeIsInFuture(valueUnderTest, 123)");
 		expression.Parameters.Add("valueUnderTest", DateTime.UtcNow);
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*second argument should be a string*");
 	}
@@ -116,7 +116,7 @@ public class DateTimeIsInFutureTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("dateTimeIsInFuture(valueUnderTest, 'Invalid/Timezone')");
 		expression.Parameters.Add("valueUnderTest", DateTime.UtcNow);
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*timezone was not a recognized*");
 	}
@@ -126,7 +126,7 @@ public class DateTimeIsInFutureTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("dateTimeIsInFuture(valueUnderTest)");
 		expression.Parameters.Add("valueUnderTest", new DateTime(1900, 1, 1));
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().NotBeNull();
 		((bool)result!).Should().BeFalse();
 	}
@@ -136,7 +136,7 @@ public class DateTimeIsInFutureTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("dateTimeIsInFuture(valueUnderTest)");
 		expression.Parameters.Add("valueUnderTest", DateTime.MaxValue);
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().NotBeNull();
 		((bool)result!).Should().BeTrue();
 	}

--- a/PanoramicData.NCalcExtensions.Test/DateTimeIsInPastTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/DateTimeIsInPastTests.cs
@@ -7,7 +7,7 @@ public class DateTimeIsInPastTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("dateTimeIsInPast(valueUnderTest)");
 		expression.Parameters.Add("valueUnderTest", DateTime.UtcNow.AddMilliseconds(-100));
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<bool>();
 
 		((bool)result).Should().BeTrue();
@@ -18,7 +18,7 @@ public class DateTimeIsInPastTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("dateTimeIsInPast(valueUnderTest)");
 		expression.Parameters.Add("valueUnderTest", DateTime.UtcNow.AddMilliseconds(100));
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<bool>();
 
 		((bool)result).Should().BeFalse();
@@ -30,7 +30,7 @@ public class DateTimeIsInPastTests : NCalcTest
 		// West Africa Time does not observe Daylight Saving, so its offset from UTC is constant
 		var expression = new ExtendedExpression("dateTimeIsInPast(valueUnderTest, 'Africa/Luanda')");
 		expression.Parameters.Add("valueUnderTest", DateTime.UtcNow.AddHours(1).AddMilliseconds(-100));
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<bool>();
 
 		((bool)result).Should().BeTrue();
@@ -42,7 +42,7 @@ public class DateTimeIsInPastTests : NCalcTest
 		// West Africa Time does not observe Daylight Saving, so its offset from UTC is constant
 		var expression = new ExtendedExpression("dateTimeIsInPast(valueUnderTest, 'Africa/Luanda')");
 		expression.Parameters.Add("valueUnderTest", DateTime.UtcNow.AddHours(2).AddMilliseconds(100));
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<bool>();
 
 		((bool)result).Should().BeFalse();
@@ -53,7 +53,7 @@ public class DateTimeIsInPastTests : NCalcTest
 	{
 		// West Africa Time does not observe Daylight Saving, so its offset from UTC is constant
 		var expression = new ExtendedExpression("dateTimeIsInPast(now(), 'Africa/Luanda')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<bool>();
 
 		((bool)result).Should().BeTrue();
@@ -65,7 +65,7 @@ public class DateTimeIsInPastTests : NCalcTest
 		// CET is always ahead of UTC, so UtcNow masquerading as CET is always in the past
 		var expression = new ExtendedExpression("dateTimeIsInPast(valueUnderTest, 'Central European Standard Time')");
 		expression.Parameters.Add("valueUnderTest", DateTime.UtcNow);
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<bool>();
 
 		((bool)result).Should().BeTrue();
@@ -75,7 +75,7 @@ public class DateTimeIsInPastTests : NCalcTest
 	public void Evaluate_1stJan2001_ReturnsTrue()
 	{
 		var expression = new ExtendedExpression("dateTimeIsInPast(toDateTime('2001-01-01T00:00:00', 'yyyy-MM-ddTHH:mm:ss'))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<bool>();
 
 		((bool)result).Should().BeTrue();
@@ -85,7 +85,7 @@ public class DateTimeIsInPastTests : NCalcTest
 	public void Evaluate_1stJan2201_ReturnsFalse()
 	{
 		var expression = new ExtendedExpression("dateTimeIsInPast(toDateTime('2201-01-01T00:00:00', 'yyyy-MM-ddTHH:mm:ss'))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<bool>();
 
 		((bool)result).Should().BeFalse();
@@ -97,7 +97,7 @@ public class DateTimeIsInPastTests : NCalcTest
 	[InlineData("dateTimeIsInPast()")]
 	[InlineData("dateTimeIsInPast(null)")]
 	public void DateTimeIsInPast_InvalidParameters_ThrowsException(string expression) => new ExtendedExpression(expression)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>();
 
@@ -106,7 +106,7 @@ public class DateTimeIsInPastTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("dateTimeIsInPast(valueUnderTest, 123)");
 		expression.Parameters.Add("valueUnderTest", DateTime.UtcNow);
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*second argument should be a string*");
 	}
@@ -116,7 +116,7 @@ public class DateTimeIsInPastTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("dateTimeIsInPast(valueUnderTest, 'Invalid/Timezone')");
 		expression.Parameters.Add("valueUnderTest", DateTime.UtcNow);
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*timezone was not a recognized*");
 	}
@@ -126,7 +126,7 @@ public class DateTimeIsInPastTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("dateTimeIsInPast(valueUnderTest)");
 		expression.Parameters.Add("valueUnderTest", new DateTime(1900, 1, 1));
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().NotBeNull();
 		((bool)result!).Should().BeTrue();
 	}
@@ -136,7 +136,7 @@ public class DateTimeIsInPastTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("dateTimeIsInPast(valueUnderTest)");
 		expression.Parameters.Add("valueUnderTest", DateTime.MaxValue);
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().NotBeNull();
 		((bool)result!).Should().BeFalse();
 	}

--- a/PanoramicData.NCalcExtensions.Test/DiagnosticComparisonTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/DiagnosticComparisonTests.cs
@@ -6,7 +6,7 @@ public class DiagnosticComparisonTests
 	public void Diagnostic_IntegerVsEmptyString_Equality()
 	{
 		var expression = new ExtendedExpression("1 == ''");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 
 		// Log what we actually get
 		Console.WriteLine($"1 == '' evaluates to: {result} (Type: {result?.GetType().Name})");
@@ -26,7 +26,7 @@ public class DiagnosticComparisonTests
 
 
 		var expression = new ExtendedExpression("1 != ''");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 
 		// Log what we actually get
 		Console.WriteLine($"1 != '' evaluates to: {result} (Type: {result?.GetType().Name})");
@@ -39,7 +39,7 @@ public class DiagnosticComparisonTests
 	public void Diagnostic_IntegerVsString1_Equality()
 	{
 		var expression = new ExtendedExpression("1 == '1'");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 
 		// Log what we actually get
 		Console.WriteLine($"1 == '1' evaluates to: {result} (Type: {result?.GetType().Name})");
@@ -52,7 +52,7 @@ public class DiagnosticComparisonTests
 	public void Diagnostic_StringVsString_Equality()
 	{
 		var expression = new ExtendedExpression("'a' == 'a'");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 
 		// Log what we actually get
 		Console.WriteLine($"'a' == 'a' evaluates to: {result} (Type: {result?.GetType().Name})");
@@ -65,7 +65,7 @@ public class DiagnosticComparisonTests
 	public void Diagnostic_IntegerVsInteger_Equality()
 	{
 		var expression = new ExtendedExpression("1 == 1");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 
 		// Log what we actually get
 		Console.WriteLine($"1 == 1 evaluates to: {result} (Type: {result?.GetType().Name})");

--- a/PanoramicData.NCalcExtensions.Test/DictionaryTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/DictionaryTests.cs
@@ -9,7 +9,7 @@ public class DictionaryTests
 	{
 		var expression = new ExtendedExpression("dictionary('p1', true, 'p2')");
 
-		var action = expression.Evaluate;
+		var action = () => expression.Evaluate(TestContext.Current.CancellationToken);
 		action.Should().Throw<FormatException>();
 	}
 
@@ -18,7 +18,7 @@ public class DictionaryTests
 	{
 		var expression = new ExtendedExpression("dictionary(0, true, 'p2', false)");
 
-		var action = expression.Evaluate;
+		var action = () => expression.Evaluate(TestContext.Current.CancellationToken);
 		action.Should().Throw<FormatException>();
 	}
 
@@ -27,7 +27,7 @@ public class DictionaryTests
 	{
 		var expression = new ExtendedExpression("dictionary('p1', true, 'p2', false)");
 
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<Dictionary<string, object?>>();
 	}
 
@@ -36,7 +36,7 @@ public class DictionaryTests
 	{
 		var expression = new ExtendedExpression("dictionary('p1', true, 'p2', false)");
 
-		var result = expression.Evaluate() as Dictionary<string, object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as Dictionary<string, object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(2);
 		result["p1"].Should().Be(true);
@@ -48,9 +48,8 @@ public class DictionaryTests
 	{
 		var expression = new ExtendedExpression("dictionary(null, true, 'p2', false)");
 
-		((Func<object?>?)expression.Evaluate)
-			.Should()
-			.Throw<FormatException>();
+		var action = () => expression.Evaluate(TestContext.Current.CancellationToken);
+		action.Should().Throw<FormatException>();
 	}
 
 	[Fact]
@@ -58,7 +57,7 @@ public class DictionaryTests
 	{
 		var expression = new ExtendedExpression("dictionary('p1', null)");
 
-		var result = expression.Evaluate() as Dictionary<string, object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as Dictionary<string, object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(1);
 		result["p1"].Should().BeNull();

--- a/PanoramicData.NCalcExtensions.Test/DistinctTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/DistinctTests.cs
@@ -14,7 +14,7 @@ public class DistinctTests : NCalcTest
 	public void Distinct_Numbers_ReturnsExpected(string input, object[] expected)
 	{
 		var expression = new ExtendedExpression($"distinct({input})");
-		expression.Evaluate().Should().BeEquivalentTo(expected);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(expected);
 	}
 
 	[Theory]
@@ -23,14 +23,14 @@ public class DistinctTests : NCalcTest
 	public void Distinct_Strings_ReturnsExpected(string input, string[] expected)
 	{
 		var expression = new ExtendedExpression($"distinct({input})");
-		expression.Evaluate().Should().BeEquivalentTo(expected);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(expected);
 	}
 
 	[Fact]
 	public void Distinct_MixedTypes_Works()
 	{
 		var expression = new ExtendedExpression("distinct(list(1, 'two', 1, 'two', 3))");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 	}
@@ -39,7 +39,7 @@ public class DistinctTests : NCalcTest
 	public void Distinct_WithNulls_PreservesOneNull()
 	{
 		var expression = new ExtendedExpression("distinct(list(1, null, 2, null, 3))");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(4); // 1, null, 2, 3
 	}
@@ -48,21 +48,21 @@ public class DistinctTests : NCalcTest
 	public void Distinct_Booleans_Works()
 	{
 		var expression = new ExtendedExpression("distinct(list(true, false, true, false, true))");
-		expression.Evaluate().Should().BeEquivalentTo(new List<bool> { true, false });
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<bool> { true, false });
 	}
 
 	[Fact]
 	public void Distinct_Doubles_Works()
 	{
 		var expression = new ExtendedExpression("distinct(list(1.5, 2.5, 1.5, 3.5))");
-		expression.Evaluate().Should().BeEquivalentTo(new List<double> { 1.5, 2.5, 3.5 });
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<double> { 1.5, 2.5, 3.5 });
 	}
 
 	[Fact]
 	public void Distinct_PreservesOrder()
 	{
 		var expression = new ExtendedExpression("distinct(list(3, 1, 2, 3, 1))");
-		expression.Evaluate().Should().BeEquivalentTo(new List<int> { 3, 1, 2 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<int> { 3, 1, 2 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
@@ -70,7 +70,7 @@ public class DistinctTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("distinct(myList)");
 		expression.Parameters["myList"] = new List<object> { 1, 2, 2, 3, 3, 3 };
-		expression.Evaluate().Should().BeEquivalentTo(new List<int> { 1, 2, 3 });
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<int> { 1, 2, 3 });
 	}
 
 	[Fact]
@@ -78,20 +78,20 @@ public class DistinctTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("distinct(myArray)");
 		expression.Parameters["myArray"] = new[] { "a", "b", "a", "c" };
-		expression.Evaluate().Should().BeEquivalentTo(new List<string> { "a", "b", "c" });
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<string> { "a", "b", "c" });
 	}
 
 	[Theory]
 	[InlineData("distinct(select(list(1, 2, 2, 3), 'n', 'n * 2'))", new object?[] { 2, 4, 6 })]
 	[InlineData("count(distinct(list(1, 1, 2, 2, 3, 3)))", 3)]
 	public void Distinct_Chained_Works(string expression, object expected)
-		=> new ExtendedExpression(expression).Evaluate().Should().BeEquivalentTo(expected);
+		=> new ExtendedExpression(expression).Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(expected);
 
 	[Fact]
 	public void Distinct_ThenJoin_Works()
 	{
 		var expression = new ExtendedExpression("join(distinct(list('x', 'y', 'x', 'z')), ',')");
-		expression.Evaluate().Should().Be("x,y,z");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("x,y,z");
 	}
 
 	[Theory]
@@ -100,6 +100,6 @@ public class DistinctTests : NCalcTest
 	[InlineData("distinct()")]
 	public void Distinct_InvalidInput_ThrowsException(string expression)
 		=> new ExtendedExpression(expression)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<Exception>();
 }

--- a/PanoramicData.NCalcExtensions.Test/EndsWithTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/EndsWithTests.cs
@@ -9,7 +9,7 @@ public class EndsWithTests
 	public void EndsWith_UsingInlineData_MatchesExpectedValue(string expressionText, bool expected)
 	{
 		var expression = new ExtendedExpression($"endsWith({expressionText})");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(expected);
 	}
 
@@ -17,20 +17,20 @@ public class EndsWithTests
 	public void EndsWith_NullFirstParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("endsWith(null, 'suffix')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>();
 	}
 
 	[Fact]
 	public void EndsWith_NullSecondParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("endsWith('string', null)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>();
 	}
 
 	[Fact]
 	public void EndsWith_NonStringParameters_ThrowsException()
 	{
 		var expression = new ExtendedExpression("endsWith(123, 456)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>();
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/EqualityTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/EqualityTests.cs
@@ -31,7 +31,7 @@ public class EqualityTests
 		extendedExpression.Parameters["nullThing"] = null;
 		extendedExpression.Parameters["x"] = x;
 		extendedExpression.Parameters["x.y"] = xDotY;
-		var result = extendedExpression.Evaluate();
+		var result = extendedExpression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/ExtendJsonDocumentTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/ExtendJsonDocumentTests.cs
@@ -9,7 +9,7 @@ public class ExtendJsonDocumentTests
 	{
 		// Test property access on JsonDocument similar to JObject extend functionality
 		var expression = new ExtendedExpression("getProperty(jsonDocument('first', 1, 'second', null, 'third', 5), 'first')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(1);
 	}
 
@@ -17,7 +17,7 @@ public class ExtendJsonDocumentTests
 	public void Extend_JsonDocument_WithNullValues_Succeeds()
 	{
 		var expression = new ExtendedExpression("getProperty(jsonDocument('First', 1, 'Second', 2, 'Third', null), 'Third')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeNull();
 	}
 
@@ -28,17 +28,17 @@ public class ExtendJsonDocumentTests
 		
 		var expression1 = new ExtendedExpression("getProperty(source, 'first')");
 		expression1.Parameters["source"] = jsonDoc;
-		var result1 = expression1.Evaluate();
+		var result1 = expression1.Evaluate(TestContext.Current.CancellationToken);
 		result1.Should().Be(1);
 
 		var expression2 = new ExtendedExpression("getProperty(source, 'second')");
 		expression2.Parameters["source"] = jsonDoc;
-		var result2 = expression2.Evaluate();
+		var result2 = expression2.Evaluate(TestContext.Current.CancellationToken);
 		result2.Should().BeNull();
 
 		var expression3 = new ExtendedExpression("getProperty(source, 'third')");
 		expression3.Parameters["source"] = jsonDoc;
-		var result3 = expression3.Evaluate();
+		var result3 = expression3.Evaluate(TestContext.Current.CancellationToken);
 		result3.Should().Be(5);
 	}
 
@@ -46,7 +46,7 @@ public class ExtendJsonDocumentTests
 	public void Extend_JsonDocument_MultiplePropertyTypes_Succeeds()
 	{
 		var expression = new ExtendedExpression("jsonDocument('First', 1, 'Second', 2, 'Third', null, 'Fourth', 'text', 'Fifth', true)");
-		var result = expression.Evaluate() as JsonDocument;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JsonDocument;
 		
 		result.Should().NotBeNull();
 		result!.RootElement.ValueKind.Should().Be(JsonValueKind.Object);

--- a/PanoramicData.NCalcExtensions.Test/ExtendTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/ExtendTests.cs
@@ -6,7 +6,7 @@ public class ExtendTests
 	public void Extend_WithInt_Succeeds()
 	{
 		var expression = new ExtendedExpression("extend(jObject('first', 1, 'second', null), list('third', 5))");
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
@@ -30,7 +30,7 @@ public class ExtendTests
 	public void Extend_WithNull_Succeeds(string expressionString)
 	{
 		var expression = new ExtendedExpression(expressionString);
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);

--- a/PanoramicData.NCalcExtensions.Test/FirstOrDefaultTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/FirstOrDefaultTests.cs
@@ -8,7 +8,7 @@ public class FirstOrDefaultTests
 	public void FirstOrDefault_MatchingItem_Succeeds()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list(1, 5, 2, 3), 'n', 'n % 2 == 0')");
-		var result = expression.Evaluate() as int?;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as int?;
 
 		result.Should().Be(2);
 	}
@@ -17,7 +17,7 @@ public class FirstOrDefaultTests
 	public void FirstOrDefault_NoMatchingItem_Succeeds()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list(1, 5, 7, 3), 'n', 'n % 2 == 0')");
-		var result = expression.Evaluate() as int?;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as int?;
 
 		result.Should().BeNull();
 	}
@@ -26,21 +26,21 @@ public class FirstOrDefaultTests
 	public void FirstOrDefault_OneParameter_ReturnsFirstElement()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list(1, 2, 3))");
-		expression.Evaluate().Should().Be(1);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(1);
 	}
 
 	[Fact]
 	public void FirstOrDefault_OneParameter_EmptyList_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list())");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void FirstOrDefault_NullFirstParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(null, 'n', 'n > 0')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*First*must be an IEnumerable*");
 	}
 
@@ -48,7 +48,7 @@ public class FirstOrDefaultTests
 	public void FirstOrDefault_NullSecondParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list(1,2,3), null, 'n > 0')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*Second*must be a string*");
 	}
 
@@ -56,7 +56,7 @@ public class FirstOrDefaultTests
 	public void FirstOrDefault_NullThirdParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list(1,2,3), 'n', null)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*Third*must be a string*");
 	}
 
@@ -65,84 +65,84 @@ public class FirstOrDefaultTests
 	public void FirstOrDefault_Strings_ReturnsFirst()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list('apple', 'banana', 'cherry'))");
-		expression.Evaluate().Should().Be("apple");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("apple");
 	}
 
 	[Fact]
 	public void FirstOrDefault_Strings_WithPredicate_ReturnsMatch()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list('apple', 'banana', 'cherry'), 's', 'startsWith(s, \"b\")')");
-		expression.Evaluate().Should().Be("banana");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("banana");
 	}
 
 	[Fact]
 	public void FirstOrDefault_Strings_NoMatch_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list('apple', 'banana', 'cherry'), 's', 'startsWith(s, \"z\")')");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void FirstOrDefault_Numbers_GreaterThan_ReturnsFirst()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list(1, 5, 10, 15), 'n', 'n > 7')");
-		expression.Evaluate().Should().Be(10);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(10);
 	}
 
 	[Fact]
 	public void FirstOrDefault_Numbers_LessThan_ReturnsFirst()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list(10, 5, 3, 1), 'n', 'n < 5')");
-		expression.Evaluate().Should().Be(3);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(3);
 	}
 
 	[Fact]
 	public void FirstOrDefault_WithNullInList_SkipsNull()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list(null, 1, 2, 3))");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void FirstOrDefault_AllNulls_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list(null, null, null))");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void FirstOrDefault_SingleItem_ReturnsIt()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list(42))");
-		expression.Evaluate().Should().Be(42);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(42);
 	}
 
 	[Fact]
 	public void FirstOrDefault_SingleItemNoMatch_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list(42), 'n', 'n < 0')");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void FirstOrDefault_Booleans_ReturnsFirstTrue()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list(false, true, false), 'b', 'b == true')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void FirstOrDefault_Doubles_Works()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list(1.5, 2.5, 3.5), 'n', 'n > 2.0')");
-		expression.Evaluate().Should().Be(2.5);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(2.5);
 	}
 
 	[Fact]
 	public void FirstOrDefault_ComplexPredicate_Works()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list(1, 5, 10, 15, 20), 'n', 'n >= 10 && n <= 15')");
-		expression.Evaluate().Should().Be(10);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(10);
 	}
 
 	[Fact]
@@ -151,7 +151,7 @@ public class FirstOrDefaultTests
 		var expression = new ExtendedExpression("firstOrDefault(myList, 'n', 'n > threshold')");
 		expression.Parameters["myList"] = new List<object> { 1, 2, 5, 10 };
 		expression.Parameters["threshold"] = 3;
-		expression.Evaluate().Should().Be(5);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(5);
 	}
 
 	[Fact]
@@ -159,41 +159,41 @@ public class FirstOrDefaultTests
 	{
 		var expression = new ExtendedExpression("firstOrDefault(myArray)");
 		expression.Parameters["myArray"] = new[] { "first", "second", "third" };
-		expression.Evaluate().Should().Be("first");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("first");
 	}
 
 	[Fact]
 	public void FirstOrDefault_ChainedWithOtherFunctions_Works()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(select(list(1, 2, 3), 'n', 'n * 2'), 'n', 'n > 3')");
-		expression.Evaluate().Should().Be(4);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(4);
 	}
 
 	[Fact]
 	public void FirstOrDefault_NonEnumerable_ThrowsException()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(42)");
-		expression.Invoking(e => e.Evaluate()).Should().Throw<FormatException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().Throw<FormatException>();
 	}
 
 	[Fact]
 	public void FirstOrDefault_NoParameters_ThrowsException()
 	{
 		var expression = new ExtendedExpression("firstOrDefault()");
-		expression.Invoking(e => e.Evaluate()).Should().Throw<Exception>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().Throw<Exception>();
 	}
 
 	[Fact]
 	public void FirstOrDefault_NegativeNumbers_Works()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list(-5, -2, 3, 7), 'n', 'n > 0')");
-		expression.Evaluate().Should().Be(3);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(3);
 	}
 
 	[Fact]
 	public void FirstOrDefault_AllMatch_ReturnsFirst()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(list(2, 4, 6, 8), 'n', 'n % 2 == 0')");
-		expression.Evaluate().Should().Be(2);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(2);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/FirstTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/FirstTests.cs
@@ -6,7 +6,7 @@ public class FirstTests
 	public void First_Succeeds()
 	{
 		var expression = new ExtendedExpression("first(list(1, 5, 2, 3, 4, 1), 'n', 'n % 2 == 0')");
-		var result = expression.Evaluate() as int?;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as int?;
 
 		result.Should().Be(2);
 	}
@@ -15,7 +15,7 @@ public class FirstTests
 	public void First_SplittingString_Succeeds()
 	{
 		var expression = new ExtendedExpression("first(split('a b c', ' '))");
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 
 		result.Should().Be("a");
 	}
@@ -26,7 +26,7 @@ public class FirstTests
 		var expression = new ExtendedExpression("store('x', list(1, 5, 2, 3)) && first(retrieve('x'), 'n', 'n % 2 == 0') == 2");
 
 		expression
-			.Evaluate()
+			.Evaluate(TestContext.Current.CancellationToken)
 			.Should()
 			.Be(true);
 	}
@@ -37,7 +37,7 @@ public class FirstTests
 		var expression = new ExtendedExpression("first(list(1, 5, 7, 3), 'n', 'n % 2 == 0')");
 
 		expression
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("No matching element found.");
@@ -48,7 +48,7 @@ public class FirstTests
 	public void First_NullFirstParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("first(null, 'n', 'n > 0')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*First*must be an IEnumerable*");
@@ -58,7 +58,7 @@ public class FirstTests
 	public void First_NonListFirstParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("first(123, 'n', 'n > 0')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*First*must be an IEnumerable*");
@@ -68,7 +68,7 @@ public class FirstTests
 	public void First_NullSecondParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("first(list(1,2,3), null, 'n > 0')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*Second*must be a string*");
@@ -78,7 +78,7 @@ public class FirstTests
 	public void First_NullThirdParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("first(list(1,2,3), 'n', null)");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*Third*must be a string*");
@@ -89,21 +89,21 @@ public class FirstTests
 	public void First_OneParameter_SingleElement_ReturnsElement()
 	{
 		var expression = new ExtendedExpression("first(list(42))");
-		expression.Evaluate().Should().Be(42);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(42);
 	}
 
 	[Fact]
 	public void First_OneParameter_MultipleElements_ReturnsFirst()
 	{
 		var expression = new ExtendedExpression("first(list(10, 20, 30))");
-		expression.Evaluate().Should().Be(10);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(10);
 	}
 
 	[Fact]
 	public void First_EmptyList_ThrowsException()
 	{
 		var expression = new ExtendedExpression("first(list())");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<Exception>();
 	}
@@ -113,14 +113,14 @@ public class FirstTests
 	public void First_Strings_WithPredicate_ReturnsMatch()
 	{
 		var expression = new ExtendedExpression("first(list('apple', 'banana', 'cherry'), 's', 'startsWith(s, \"b\")')");
-		expression.Evaluate().Should().Be("banana");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("banana");
 	}
 
 	[Fact]
 	public void First_Strings_NoMatch_ThrowsException()
 	{
 		var expression = new ExtendedExpression("first(list('apple', 'banana', 'cherry'), 's', 'startsWith(s, \"z\")')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("No matching element found.");
@@ -130,55 +130,55 @@ public class FirstTests
 	public void First_Numbers_GreaterThan_ReturnsFirst()
 	{
 		var expression = new ExtendedExpression("first(list(1, 5, 10, 15), 'n', 'n > 7')");
-		expression.Evaluate().Should().Be(10);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(10);
 	}
 
 	[Fact]
 	public void First_Numbers_LessThan_ReturnsFirst()
 	{
 		var expression = new ExtendedExpression("first(list(10, 5, 3, 1), 'n', 'n < 5')");
-		expression.Evaluate().Should().Be(3);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(3);
 	}
 
 	[Fact]
 	public void First_Doubles_Works()
 	{
 		var expression = new ExtendedExpression("first(list(1.5, 2.5, 3.5), 'n', 'n > 2.0')");
-		expression.Evaluate().Should().Be(2.5);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(2.5);
 	}
 
 	[Fact]
 	public void First_ComplexPredicate_Works()
 	{
 		var expression = new ExtendedExpression("first(list(1, 5, 10, 15, 20), 'n', 'n >= 10 && n <= 15')");
-		expression.Evaluate().Should().Be(10);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(10);
 	}
 
 	[Fact]
 	public void First_NegativeNumbers_Works()
 	{
 		var expression = new ExtendedExpression("first(list(-5, -2, 3, 7), 'n', 'n > 0')");
-		expression.Evaluate().Should().Be(3);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(3);
 	}
 
 	[Fact]
 	public void First_AllMatch_ReturnsFirst()
 	{
 		var expression = new ExtendedExpression("first(list(2, 4, 6, 8), 'n', 'n % 2 == 0')");
-		expression.Evaluate().Should().Be(2);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(2);
 	}
 
 	[Fact]
 	public void First_LastItemMatches_ReturnsLast()
 	{
 		var expression = new ExtendedExpression("first(list(1, 3, 5, 8), 'n', 'n % 2 == 0')");
-		expression.Evaluate().Should().Be(8);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(8);
 	}
 
 	[Fact]
 	public void First_Booleans_ReturnsFirstTrue()
 	{
 		var expression = new ExtendedExpression("first(list(false, true, false), 'b', 'b == true')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/FormatTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/FormatTests.cs
@@ -5,7 +5,7 @@ public class FormatTests
 	[Fact]
 	public void Format_InvalidFormat_Fails()
 		=> new ExtendedExpression("format(1, 1)")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<ArgumentException>()
 			.WithMessage("format function - expected second argument to be a format string");
@@ -15,7 +15,7 @@ public class FormatTests
 	[InlineData("format(1)")]
 	public void Format_NotTwoParameters_Fails(string inputText)
 		=> new ExtendedExpression(inputText)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<ArgumentException>()
 			.WithMessage("format function - expected between 2 and 3 arguments");
@@ -24,7 +24,7 @@ public class FormatTests
 	[InlineData("format(1, 2, 3)")]
 	public void Format_ThreeParametersForInt_Fails(string inputText)
 		=> new ExtendedExpression(inputText)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<ArgumentException>()
 			.WithMessage("format function - expected second argument to be a format string");
@@ -33,21 +33,21 @@ public class FormatTests
 	public void Format_IntFormat_Succeeds()
 	{
 		var expression = new ExtendedExpression("format(1, '00')");
-		expression.Evaluate().Should().Be("01");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("01");
 	}
 
 	[Fact]
 	public void Format_DoubleFormat_Succeeds()
 	{
 		var expression = new ExtendedExpression("format(1.0, '00')");
-		expression.Evaluate().Should().Be("01");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("01");
 	}
 
 	[Fact]
 	public void Format_DateTimeFormat_Succeeds()
 	{
 		var expression = new ExtendedExpression("format(dateTime('UTC', 'yyyy-MM-dd'), 'yyyy-MM-dd')");
-		expression.Evaluate().Should().Be(DateTime.UtcNow.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(DateTime.UtcNow.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
 	}
 
 	[Fact]
@@ -55,21 +55,21 @@ public class FormatTests
 	{
 		var expression = new ExtendedExpression("format(theDateTime, 'yyyy-MM-dd HH:mm', 'Eastern Standard Time')");
 		expression.Parameters.Add("theDateTime", DateTime.Parse("2020-03-13 16:00", CultureInfo.InvariantCulture));
-		expression.Evaluate().Should().Be("2020-03-13 12:00");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("2020-03-13 12:00");
 	}
 
 	[Fact]
 	public void Format_StringFormat_Succeeds()
 	{
 		var expression = new ExtendedExpression("format('02', '0')");
-		expression.Evaluate().Should().Be("2");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("2");
 	}
 
 	[Fact]
 	public void Format_DateFormat_DayOfYear_Succeeds()
 	{
 		var expression = new ExtendedExpression("format('2021-11-29', 'dayOfYear')");
-		expression.Evaluate().Should().Be("333");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("333");
 	}
 
 	// Additional format type tests
@@ -77,14 +77,14 @@ public class FormatTests
 	public void Format_NullValue_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("format(null, 'yyyy-MM-dd')");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void Format_LongInteger_Succeeds()
 	{
 		var expression = new ExtendedExpression("format(123456789, '#,##0')");
-		expression.Evaluate().Should().Be("123,456,789");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("123,456,789");
 	}
 
 	[Fact]
@@ -92,7 +92,7 @@ public class FormatTests
 	{
 		var expression = new ExtendedExpression("format(theDecimal, '0.00')");
 		expression.Parameters["theDecimal"] = 123.456m;
-		expression.Evaluate().Should().Be("123.46");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("123.46");
 	}
 
 	[Fact]
@@ -100,7 +100,7 @@ public class FormatTests
 	{
 		var expression = new ExtendedExpression("format(theFloat, '0.00')");
 		expression.Parameters["theFloat"] = 123.456f;
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().StartWith("123.4");
 	}
 
@@ -109,7 +109,7 @@ public class FormatTests
 	{
 		var expression = new ExtendedExpression("format(theDateTimeOffset, 'yyyy-MM-dd')");
 		expression.Parameters["theDateTimeOffset"] = new DateTimeOffset(2021, 1, 15, 0, 0, 0, TimeSpan.Zero);
-		expression.Evaluate().Should().Be("2021-01-15");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("2021-01-15");
 	}
 
 	[Fact]
@@ -117,7 +117,7 @@ public class FormatTests
 	{
 		var expression = new ExtendedExpression("format(theDateTime, 'yyyy-MM-dd', 'InvalidTimeZone')");
 		expression.Parameters["theDateTime"] = DateTime.UtcNow;
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<Exception>();
 	}
 
@@ -126,7 +126,7 @@ public class FormatTests
 	{
 		var expression = new ExtendedExpression("format(theDateTime, 'dd MMM yyyy')");
 		expression.Parameters["theDateTime"] = new DateTime(2021, 3, 15);
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().Contain("15");
 		result.Should().Contain("2021");
 	}
@@ -171,7 +171,7 @@ public class FormatTests
 	public void Format_DateFormat_WeekOfMonth_Succeeds(string dateTimeString, int expectedWeekOfMonth)
 	{
 		var expression = new ExtendedExpression($"format('{dateTimeString}', 'weekOfMonth')");
-		expression.Evaluate().Should().Be(expectedWeekOfMonth.ToString(CultureInfo.InvariantCulture));
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(expectedWeekOfMonth.ToString(CultureInfo.InvariantCulture));
 	}
 
 	[Theory(DisplayName = "weekDayOfMonth calculates the number of times (including this time) that the day of week has occurred so far.")]
@@ -181,21 +181,21 @@ public class FormatTests
 	public void Format_DateFormat_WeekDayOfMonth_Succeeds(string dateTimeString, int expectedWeekDayOfMonth)
 	{
 		var expression = new ExtendedExpression($"format('{dateTimeString}', 'weekDayOfMonth')");
-		expression.Evaluate().Should().Be(expectedWeekDayOfMonth.ToString(CultureInfo.InvariantCulture));
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(expectedWeekDayOfMonth.ToString(CultureInfo.InvariantCulture));
 	}
 
 	[Fact]
 	public void Format_DateFormat_WeekOfMonthText_Succeeds()
 	{
 		var expression = new ExtendedExpression("format('2021-11-30', 'weekOfMonthText')");
-		expression.Evaluate().Should().Be("last");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("last");
 	}
 
 	[Fact]
 	public void Format_DateFormat_WeekOfYear_Succeeds()
 	{
 		var expression = new ExtendedExpression("format('2024-06-15', 'weekOfYear')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().NotBeNull();
 		int.Parse(result.ToString()!, CultureInfo.InvariantCulture).Should().BeGreaterThan(0).And.BeLessThanOrEqualTo(53);
 	}
@@ -204,20 +204,20 @@ public class FormatTests
 	public void Format_DateFormat_IsoWeekOfYear_Succeeds()
 	{
 		var expression = new ExtendedExpression("format('2024-01-01', 'isoWeekOfYear')");
-		expression.Evaluate().Should().Be("1");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("1");
 	}
 
 	[Fact]
 	public void Format_DateTimeStringFormat_Succeeds()
 	{
 		var expression = new ExtendedExpression("format('01/01/2019', 'yyyy-MM-dd')");
-		expression.Evaluate().Should().Be("2019-01-01");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("2019-01-01");
 	}
 
 	[Fact]
 	public void Format_InvalidStringFormat_Succeeds()
 		=> new ExtendedExpression("format('XXX', 'yyyy-MM-dd')")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<FormatException>()
 			.WithMessage("Could not parse 'XXX' as a number or date.");
@@ -226,7 +226,7 @@ public class FormatTests
 	public void Format_SingleH_Succeeds()
 	{
 		var expression = new ExtendedExpression("parseInt(format(toDateTime((dateTimeAsEpochMs('2021-01-17 12:45:00', 'yyyy-MM-dd HH:mm:ss')) + (dateTimeAsEpochMs('1970-01-01 08:00:00', 'yyyy-MM-dd HH:mm:ss')), 'ms', 'UTC'), 'HH'))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(20);
 	}
 
@@ -235,14 +235,14 @@ public class FormatTests
 	public void Format_ZeroInteger_Succeeds()
 	{
 		var expression = new ExtendedExpression("format(0, '0000')");
-		expression.Evaluate().Should().Be("0000");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("0000");
 	}
 
 	[Fact]
 	public void Format_NegativeNumber_Succeeds()
 	{
 		var expression = new ExtendedExpression("format(-123, '0000')");
-		expression.Evaluate().Should().Be("-0123");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("-0123");
 	}
 
 	[Fact]
@@ -250,7 +250,7 @@ public class FormatTests
 	{
 		var expression = new ExtendedExpression("format(theLong, '#,##0')");
 		expression.Parameters["theLong"] = 9223372036854775807L;
-		expression.Evaluate().Should().Be("9,223,372,036,854,775,807");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("9,223,372,036,854,775,807");
 	}
 
 	[Fact]
@@ -259,6 +259,6 @@ public class FormatTests
 		var expression = new ExtendedExpression("format(myValue, myFormat)");
 		expression.Parameters["myValue"] = 42;
 		expression.Parameters["myFormat"] = "000";
-		expression.Evaluate().Should().Be("042");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("042");
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/GetPropertiesJsonDocumentTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/GetPropertiesJsonDocumentTests.cs
@@ -9,7 +9,7 @@ public class GetPropertiesJsonDocumentTests
 	public void GetProperties_JsonDocument_ReturnsPropertyNames()
 	{
 		var expression = new ExtendedExpression("getProperties(jsonDocument('name', 'John', 'age', 30, 'active', true))");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 		result.Should().Contain("name");
@@ -21,7 +21,7 @@ public class GetPropertiesJsonDocumentTests
 	public void GetProperties_EmptyJsonDocument_ReturnsEmptyList()
 	{
 		var expression = new ExtendedExpression("getProperties(jsonDocument())");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().BeEmpty();
 	}
@@ -32,7 +32,7 @@ public class GetPropertiesJsonDocumentTests
 		var jsonDoc = JsonDocument.Parse("{\"person\": {\"name\": \"Jane\", \"age\": 25}}");
 		var expression = new ExtendedExpression("getProperties(person)");
 		expression.Parameters["person"] = jsonDoc.RootElement.GetProperty("person");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(2);
 		result.Should().Contain("name");
@@ -44,7 +44,7 @@ public class GetPropertiesJsonDocumentTests
 	{
 		// Ensure getProperties throws exception for arrays, consistent with getProperty behavior
 		var expression = new ExtendedExpression("getProperties(jsonArray(1, 2, 3))");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*must be an object to get properties*");
 	}
@@ -53,7 +53,7 @@ public class GetPropertiesJsonDocumentTests
 	public void GetProperties_JsonDocument_FromParsedJson_Succeeds()
 	{
 		var expression = new ExtendedExpression("getProperties(parse('JsonDocument', '{\"A\": 1, \"B\": 2}'))");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(2);
 		result.Should().Contain("A");
@@ -64,7 +64,7 @@ public class GetPropertiesJsonDocumentTests
 	public void GetProperties_JsonDocument_NestedObject_ReturnsTopLevelProperties()
 	{
 		var expression = new ExtendedExpression("getProperties(jsonDocument('outer', jsonDocument('inner', 'value'), 'simple', 'text'))");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(2);
 		result.Should().Contain("outer");
@@ -78,7 +78,7 @@ public class GetPropertiesJsonDocumentTests
 		var expression = new ExtendedExpression("getProperties(stringElement)");
 		expression.Parameters["stringElement"] = jsonDoc.RootElement.GetProperty("stringValue");
 
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*must be an object to get properties*");
 	}

--- a/PanoramicData.NCalcExtensions.Test/GetPropertiesTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/GetPropertiesTests.cs
@@ -12,7 +12,7 @@ public class GetPropertiesTests
 	{
 		var year = 2019;
 		var expression = new ExtendedExpression($"getProperties(toDateTime('{year}-01-01', 'yyyy-MM-dd'))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<List<string>>();
 		result.Should().BeEquivalentTo(DateTimePropertyNames);
 	}
@@ -21,7 +21,7 @@ public class GetPropertiesTests
 	public void GetProperties_FromJObject()
 	{
 		var expression = new ExtendedExpression("getProperties(parse('jObject', '{ \"A\": 1, \"B\": 2 }'))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<List<string>>();
 		result.Should().BeEquivalentTo(ExpectedJObjectPropertyNames);
 	}

--- a/PanoramicData.NCalcExtensions.Test/GetPropertyJsonDocumentTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/GetPropertyJsonDocumentTests.cs
@@ -8,7 +8,7 @@ public class GetPropertyJsonDocumentTests
 	public void GetProperty_JsonDocument_ReturnsCorrectValue()
 	{
 		var expression = new ExtendedExpression("getProperty(jsonDocument('name', 'John', 'age', 30), 'name')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be("John");
 	}
 
@@ -16,7 +16,7 @@ public class GetPropertyJsonDocumentTests
 	public void GetProperty_JsonDocument_ReturnsNumber()
 	{
 		var expression = new ExtendedExpression("getProperty(jsonDocument('name', 'John', 'age', 30), 'age')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(30);
 	}
 
@@ -24,7 +24,7 @@ public class GetPropertyJsonDocumentTests
 	public void GetProperty_JsonDocument_ReturnsNull_ForNullValue()
 	{
 		var expression = new ExtendedExpression("getProperty(jsonDocument('name', 'John', 'spouse', null), 'spouse')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeNull();
 	}
 
@@ -32,7 +32,7 @@ public class GetPropertyJsonDocumentTests
 	public void GetProperty_JsonDocument_ReturnsNull_ForMissingProperty()
 	{
 		var expression = new ExtendedExpression("getProperty(jsonDocument('name', 'John'), 'age')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeNull();
 	}
 
@@ -42,7 +42,7 @@ public class GetPropertyJsonDocumentTests
 		var jsonDoc = JsonDocument.Parse("{\"person\": {\"name\": \"Jane\", \"age\": 25}}");
 		var expression = new ExtendedExpression("getProperty(person, 'name')");
 		expression.Parameters["person"] = jsonDoc.RootElement.GetProperty("person");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be("Jane");
 	}
 
@@ -50,7 +50,7 @@ public class GetPropertyJsonDocumentTests
 	public void GetProperty_JsonDocument_Boolean_ReturnsBoolean()
 	{
 		var expression = new ExtendedExpression("getProperty(jsonDocument('active', true), 'active')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -58,7 +58,7 @@ public class GetPropertyJsonDocumentTests
 	public void GetProperty_JsonDocument_FromParsedJson_Succeeds()
 	{
 		var expression = new ExtendedExpression("getProperty(parse('JsonDocument', '{\"A\": 1, \"B\": 2}'), 'B')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(2);
 	}
 
@@ -66,7 +66,7 @@ public class GetPropertyJsonDocumentTests
 	public void GetProperty_JsonDocument_NestedObject_ReturnsJsonElement()
 	{
 		var expression = new ExtendedExpression("getProperty(jsonDocument('nested', jsonDocument('inner', 'value')), 'nested')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<JsonElement>();
 		
 		var jsonElement = (JsonElement)result;
@@ -77,7 +77,7 @@ public class GetPropertyJsonDocumentTests
 	public void GetProperty_JsonDocument_Array_ReturnsJsonElement()
 	{
 		var expression = new ExtendedExpression("getProperty(jsonDocument('items', jsonArray(1, 2, 3)), 'items')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<JsonElement>();
 		
 		var jsonElement = (JsonElement)result;
@@ -88,7 +88,7 @@ public class GetPropertyJsonDocumentTests
 	public void GetProperty_JsonDocument_InvalidProperty_ThrowsException()
 	{
 		var expression = new ExtendedExpression("getProperty(jsonArray(1, 2, 3), 'nonexistent')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*must be an object*");
 	}
@@ -98,7 +98,7 @@ public class GetPropertyJsonDocumentTests
 	{
 		// Test that JsonDocument property access returns the same types as JObject
 		var expression = new ExtendedExpression("getProperty(parse('JsonDocument', '{\"A\": 1, \"B\": 2}'), 'B')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<int>();
 		result.Should().Be(2);
 	}

--- a/PanoramicData.NCalcExtensions.Test/GetPropertyTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/GetPropertyTests.cs
@@ -7,7 +7,7 @@ public class GetPropertyTests
 	{
 		var year = 2019;
 		var expression = new ExtendedExpression($"getProperty(toDateTime('{year}-01-01', 'yyyy-MM-dd'), 'Year')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<int>();
 		result.Should().Be(year);
 	}
@@ -16,7 +16,7 @@ public class GetPropertyTests
 	public void GetProperty_FromJObject()
 	{
 		var expression = new ExtendedExpression($"getProperty(parse('jObject', '{{ \"A\": 1, \"B\": 2 }}'), 'B')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<int>();
 		result.Should().Be(2);
 	}
@@ -25,7 +25,7 @@ public class GetPropertyTests
 	public void GetProperty_FromDictionary()
 	{
 		var expression = new ExtendedExpression($"getProperty(dictionary('A', 2, 'B', 'Target'), 'B')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<string>();
 		result.Should().Be("Target");
 	}
@@ -35,14 +35,14 @@ public class GetPropertyTests
 	public void GetProperty_JObject_IntegerProperty_ReturnsInt()
 	{
 		var expression = new ExtendedExpression("getProperty(parse('jObject', '{\"count\": 42}'), 'count')");
-		expression.Evaluate().Should().Be(42);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(42);
 	}
 
 	[Fact]
 	public void GetProperty_JObject_FloatProperty_ReturnsFloat()
 	{
 		var expression = new ExtendedExpression("getProperty(parse('jObject', '{\"value\": 3.14}'), 'value')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<float>();
 	}
 
@@ -50,28 +50,28 @@ public class GetPropertyTests
 	public void GetProperty_JObject_StringProperty_ReturnsString()
 	{
 		var expression = new ExtendedExpression("getProperty(parse('jObject', '{\"name\": \"test\"}'), 'name')");
-		expression.Evaluate().Should().Be("test");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("test");
 	}
 
 	[Fact]
 	public void GetProperty_JObject_BooleanProperty_ReturnsBool()
 	{
 		var expression = new ExtendedExpression("getProperty(parse('jObject', '{\"flag\": true}'), 'flag')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void GetProperty_JObject_NullProperty_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("getProperty(parse('jObject', '{\"value\": null}'), 'value')");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void GetProperty_JObject_ArrayProperty_ReturnsJArray()
 	{
 		var expression = new ExtendedExpression("getProperty(parse('jObject', '{\"items\": [1,2,3]}'), 'items')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<JArray>();
 	}
 
@@ -79,7 +79,7 @@ public class GetPropertyTests
 	public void GetProperty_JObject_ObjectProperty_ReturnsJObject()
 	{
 		var expression = new ExtendedExpression("getProperty(parse('jObject', '{\"nested\": {\"a\":1}}'), 'nested')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<JObject>();
 	}
 
@@ -87,7 +87,7 @@ public class GetPropertyTests
 	public void GetProperty_JObject_DateProperty_ReturnsDateTime()
 	{
 		var expression = new ExtendedExpression("getProperty(parse('jObject', '{\"date\": \"2020-01-01T00:00:00Z\"}'), 'date')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		// Could be DateTime or string depending on JSON parsing
 		result.Should().NotBeNull();
 	}
@@ -97,42 +97,42 @@ public class GetPropertyTests
 	public void GetProperty_JsonDocument_StringProperty_ReturnsString()
 	{
 		var expression = new ExtendedExpression("getProperty(jsonDocument('name', 'John', 'age', 30), 'name')");
-		expression.Evaluate().Should().Be("John");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("John");
 	}
 
 	[Fact]
 	public void GetProperty_JsonDocument_IntProperty_ReturnsInt()
 	{
 		var expression = new ExtendedExpression("getProperty(jsonDocument('name', 'John', 'age', 30), 'age')");
-		expression.Evaluate().Should().Be(30);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(30);
 	}
 
 	[Fact]
 	public void GetProperty_JsonDocument_BooleanTrue_ReturnsTrue()
 	{
 		var expression = new ExtendedExpression("getProperty(jsonDocument('isActive', true), 'isActive')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void GetProperty_JsonDocument_BooleanFalse_ReturnsFalse()
 	{
 		var expression = new ExtendedExpression("getProperty(jsonDocument('isActive', false), 'isActive')");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	[Fact]
 	public void GetProperty_JsonDocument_NullProperty_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("getProperty(jsonDocument('value', null), 'value')");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void GetProperty_JsonDocument_MissingProperty_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("getProperty(jsonDocument('name', 'John'), 'age')");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
@@ -140,7 +140,7 @@ public class GetPropertyTests
 	{
 		var expression = new ExtendedExpression("getProperty(TheDoc, 'bigNumber')");
 		expression.Parameters["TheDoc"] = System.Text.Json.JsonDocument.Parse("{\"bigNumber\": 9223372036854775807}");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<long>();
 	}
 
@@ -149,7 +149,7 @@ public class GetPropertyTests
 	{
 		var expression = new ExtendedExpression("getProperty(TheDoc, 'decimal')");
 		expression.Parameters["TheDoc"] = System.Text.Json.JsonDocument.Parse("{\"decimal\": 3.14159}");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<double>();
 	}
 
@@ -158,14 +158,14 @@ public class GetPropertyTests
 	public void GetProperty_Dictionary_IntValue_ReturnsInt()
 	{
 		var expression = new ExtendedExpression("getProperty(dictionary('count', 5), 'count')");
-		expression.Evaluate().Should().Be(5);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(5);
 	}
 
 	[Fact]
 	public void GetProperty_Dictionary_NullValue_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("getProperty(dictionary('value', null), 'value')");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	// Regular .NET object tests
@@ -173,21 +173,21 @@ public class GetPropertyTests
 	public void GetProperty_DateTime_Month_ReturnsMonth()
 	{
 		var expression = new ExtendedExpression("getProperty(toDateTime('2020-03-15', 'yyyy-MM-dd'), 'Month')");
-		expression.Evaluate().Should().Be(3);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(3);
 	}
 
 	[Fact]
 	public void GetProperty_DateTime_Day_ReturnsDay()
 	{
 		var expression = new ExtendedExpression("getProperty(toDateTime('2020-03-15', 'yyyy-MM-dd'), 'Day')");
-		expression.Evaluate().Should().Be(15);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(15);
 	}
 
 	[Fact]
 	public void GetProperty_String_Length_ReturnsLength()
 	{
 		var expression = new ExtendedExpression("getProperty('hello', 'Length')");
-		expression.Evaluate().Should().Be(5);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(5);
 	}
 
 	// Error cases
@@ -195,7 +195,7 @@ public class GetPropertyTests
 	public void GetProperty_NullObject_ThrowsException()
 	{
 		var expression = new ExtendedExpression("getProperty(null, 'property')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*first parameter cannot be null*");
 	}
@@ -204,7 +204,7 @@ public class GetPropertyTests
 	public void GetProperty_NullPropertyName_ThrowsException()
 	{
 		var expression = new ExtendedExpression("getProperty(jsonDocument('a', 1), null)");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*requires two parameters*");
 	}
@@ -213,7 +213,7 @@ public class GetPropertyTests
 	public void GetProperty_NonExistentProperty_ThrowsException()
 	{
 		var expression = new ExtendedExpression("getProperty(toDateTime('2020-01-01', 'yyyy-MM-dd'), 'NonExistent')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*Could not find property*");
 	}
@@ -222,7 +222,7 @@ public class GetPropertyTests
 	public void GetProperty_JsonDocument_NonObjectRoot_ThrowsException()
 	{
 		var expression = new ExtendedExpression("getProperty(parse('jsonArray', '[1,2,3]'), 'property')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*must be an object*");
 	}
@@ -233,7 +233,7 @@ public class GetPropertyTests
 	{
 		var expression = new ExtendedExpression("getProperty(TheDoc, 'nested')");
 		expression.Parameters["TheDoc"] = System.Text.Json.JsonDocument.Parse("{\"nested\": {\"a\": 1}}");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<System.Text.Json.JsonElement>();
 	}
 
@@ -242,7 +242,7 @@ public class GetPropertyTests
 	{
 		var expression = new ExtendedExpression("getProperty(TheDoc, 'items')");
 		expression.Parameters["TheDoc"] = System.Text.Json.JsonDocument.Parse("{\"items\": [1,2,3]}");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<System.Text.Json.JsonElement>();
 	}
 
@@ -253,7 +253,7 @@ public class GetPropertyTests
 		var expression = new ExtendedExpression("getProperty(myObject, myProperty)");
 		expression.Parameters["myObject"] = System.Text.Json.JsonDocument.Parse("{\"test\": 123}");
 		expression.Parameters["myProperty"] = "test";
-		expression.Evaluate().Should().Be(123);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(123);
 	}
 
 	// Test missing parameters
@@ -261,7 +261,7 @@ public class GetPropertyTests
 	public void GetProperty_MissingSecondParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("getProperty(jsonDocument('a', 1))");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<Exception>();
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/HumanizeTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/HumanizeTests.cs
@@ -11,7 +11,7 @@ public class HumanizeTests
 	public void Humanize_UsingInlineData_MatchesExpectedValue(string expressionText, string dataType, string expected)
 	{
 		var expression = new ExtendedExpression($"humanize({expressionText},'{dataType}')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(expected);
 	}
 
@@ -20,21 +20,21 @@ public class HumanizeTests
 	public void Humanize_Milliseconds_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression("humanize(60000, 'milliseconds')");
-		expression.Evaluate().Should().Be("1 minute");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("1 minute");
 	}
 
 	[Fact]
 	public void Humanize_Seconds_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression("humanize(120, 'seconds')");
-		expression.Evaluate().Should().Be("2 minutes");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("2 minutes");
 	}
 
 	[Fact]
 	public void Humanize_Minutes_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression("humanize(90, 'minutes')");
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().Contain("hour"); // 90 minutes = 1 hour 30 minutes
 	}
 
@@ -42,7 +42,7 @@ public class HumanizeTests
 	public void Humanize_Hours_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression("humanize(24, 'hours')");
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().Contain("day"); // 24 hours = 1 day
 	}
 
@@ -50,7 +50,7 @@ public class HumanizeTests
 	public void Humanize_Days_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression("humanize(7, 'days')");
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().Contain("day"); // 7 days (might show as "7 days" or "1 week" depending on library)
 	}
 
@@ -58,7 +58,7 @@ public class HumanizeTests
 	public void Humanize_Weeks_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression("humanize(2, 'weeks')");
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().Contain("day"); // 2 weeks = 14 days
 	}
 
@@ -66,7 +66,7 @@ public class HumanizeTests
 	public void Humanize_Years_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression("humanize(1, 'years')");
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().Contain("day"); // Humanizer converts 1 year to days (365 days 6 hours)
 	}
 
@@ -79,7 +79,7 @@ public class HumanizeTests
 	public void Humanize_CaseInsensitive_Works(string timeUnit)
 	{
 		var expression = new ExtendedExpression($"humanize(60, '{timeUnit}')");
-		expression.Evaluate().Should().Be("1 minute");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("1 minute");
 	}
 
 	// Test zero value
@@ -87,7 +87,7 @@ public class HumanizeTests
 	public void Humanize_ZeroValue_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression("humanize(0, 'seconds')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		// Zero values return empty string - just verify it doesn't throw
 		result.Should().NotBeNull();
 	}
@@ -97,7 +97,7 @@ public class HumanizeTests
 	public void Humanize_NegativeValue_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression("humanize(-60, 'seconds')");
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		// Negative values might return empty or special format
 		result.Should().NotBeNull();
 	}
@@ -107,7 +107,7 @@ public class HumanizeTests
 	public void Humanize_LargeValue_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression("humanize(86400, 'seconds')"); // 1 day
-		expression.Evaluate().Should().Be("1 day");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("1 day");
 	}
 
 	// Test fractional values
@@ -115,7 +115,7 @@ public class HumanizeTests
 	public void Humanize_FractionalValue_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression("humanize(1.5, 'hours')");
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().Contain("minute"); // 1.5 hours = 1 hour 30 minutes
 	}
 
@@ -124,7 +124,7 @@ public class HumanizeTests
 	public void Humanize_NullFirstParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("humanize(null, 'seconds')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>();
 	}
 
@@ -132,7 +132,7 @@ public class HumanizeTests
 	public void Humanize_NullSecondParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("humanize(60, null)");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>();
 	}
 
@@ -140,7 +140,7 @@ public class HumanizeTests
 	public void Humanize_InvalidTimeUnit_ThrowsException()
 	{
 		var expression = new ExtendedExpression("humanize(60, 'invalid')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*time unit*");
 	}
@@ -149,7 +149,7 @@ public class HumanizeTests
 	public void Humanize_NonNumericFirstParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("humanize('not a number', 'seconds')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*floating-point number*");
 	}
@@ -160,7 +160,7 @@ public class HumanizeTests
 		// Test with a value that would cause overflow
 		var expression = new ExtendedExpression("humanize(theValue, 'milliseconds')");
 		expression.Parameters["theValue"] = double.MaxValue;
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*floating-point number*");
 	}
@@ -170,7 +170,7 @@ public class HumanizeTests
 	public void Humanize_MissingParameters_ThrowsException()
 	{
 		var expression = new ExtendedExpression("humanize(60)");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<Exception>(); // Will throw due to missing parameter
 	}
 
@@ -179,7 +179,7 @@ public class HumanizeTests
 	public void Humanize_OneMillisecond_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression("humanize(1, 'milliseconds')");
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		// Very small values might return empty
 		result.Should().NotBeNull();
 	}
@@ -188,7 +188,7 @@ public class HumanizeTests
 	public void Humanize_OneSecond_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression("humanize(1, 'seconds')");
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().NotBeNullOrEmpty();
 	}
 
@@ -196,7 +196,7 @@ public class HumanizeTests
 	public void Humanize_MultipleYears_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression("humanize(2, 'years')");
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().Contain("day"); // Humanizer converts years to days
 	}
 
@@ -207,7 +207,7 @@ public class HumanizeTests
 		var expression = new ExtendedExpression("humanize(myValue, myUnit)");
 		expression.Parameters["myValue"] = 120.0; // Use double to ensure it works
 		expression.Parameters["myUnit"] = "seconds";
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().Contain("minute"); // 120 seconds = 2 minutes
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/IfTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/IfTests.cs
@@ -8,7 +8,7 @@ public class IfTests
 	public void If_InlineData_ResultsMatchExpectation(string expressionText, string trueValue, string falseValue, object expected)
 	{
 		var expression = new ExtendedExpression($"if({expressionText},'{trueValue}','{falseValue}')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(expected);
 	}
 
@@ -18,35 +18,35 @@ public class IfTests
 	public void If_TrueCondition_ReturnsTrueValue()
 	{
 		var expression = new ExtendedExpression("if(true, 'success', 'failure')");
-		expression.Evaluate().Should().Be("success");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("success");
 	}
 
 	[Fact]
 	public void If_FalseCondition_ReturnsFalseValue()
 	{
 		var expression = new ExtendedExpression("if(false, 'success', 'failure')");
-		expression.Evaluate().Should().Be("failure");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("failure");
 	}
 
 	[Fact]
 	public void If_NumericComparison_ReturnsCorrectBranch()
 	{
 		var expression = new ExtendedExpression("if(5 > 3, 100, 200)");
-		expression.Evaluate().Should().Be(100);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(100);
 	}
 
 	[Fact]
 	public void If_WithNullTrueValue_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("if(true, null, 'value')");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void If_WithNullFalseValue_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("if(false, 'value', null)");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Theory]
@@ -55,7 +55,7 @@ public class IfTests
 	[InlineData("if(true, 'value')")]
 	[InlineData("if(true, 'value1', 'value2', 'value3')")]
 	public void If_WrongParameterCount_ThrowsException(string expression) => new ExtendedExpression(expression)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*requires three parameters*");
@@ -65,7 +65,7 @@ public class IfTests
 	[InlineData("if('text', 'true', 'false')")]
 	[InlineData("if(null, 'true', 'false')")]
 	public void If_NonBooleanCondition_ThrowsException(string expression) => new ExtendedExpression(expression)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*parameter 1*");
@@ -74,42 +74,42 @@ public class IfTests
 	public void If_ComplexExpression_InTrueBranch_Evaluates()
 	{
 		var expression = new ExtendedExpression("if(true, 2 + 2, 3 + 3)");
-		expression.Evaluate().Should().Be(4);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(4);
 	}
 
 	[Fact]
 	public void If_ComplexExpression_InFalseBranch_Evaluates()
 	{
 		var expression = new ExtendedExpression("if(false, 2 + 2, 3 + 3)");
-		expression.Evaluate().Should().Be(6);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(6);
 	}
 
 	[Fact]
 	public void If_NestedIf_TrueBranch_EvaluatesCorrectly()
 	{
 		var expression = new ExtendedExpression("if(true, if(true, 'inner-true', 'inner-false'), 'outer-false')");
-		expression.Evaluate().Should().Be("inner-true");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("inner-true");
 	}
 
 	[Fact]
 	public void If_NestedIf_FalseBranch_EvaluatesCorrectly()
 	{
 		var expression = new ExtendedExpression("if(false, 'outer-true', if(true, 'inner-true', 'inner-false'))");
-		expression.Evaluate().Should().Be("inner-true");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("inner-true");
 	}
 
 	[Fact]
 	public void If_WithFunctionCall_InTrueBranch_Evaluates()
 	{
 		var expression = new ExtendedExpression("if(true, toUpper('hello'), toLower('WORLD'))");
-		expression.Evaluate().Should().Be("HELLO");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("HELLO");
 	}
 
 	[Fact]
 	public void If_WithFunctionCall_InFalseBranch_Evaluates()
 	{
 		var expression = new ExtendedExpression("if(false, toUpper('hello'), toLower('WORLD'))");
-		expression.Evaluate().Should().Be("world");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("world");
 	}
 
 	[Fact]
@@ -117,20 +117,20 @@ public class IfTests
 	{
 		var expression = new ExtendedExpression("if(x > 10, 'big', 'small')");
 		expression.Parameters["x"] = 15;
-		expression.Evaluate().Should().Be("big");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("big");
 	}
 
 	[Fact]
 	public void If_WithListOperation_InTrueBranch_Evaluates()
 	{
 		var expression = new ExtendedExpression("if(true, length(list(1,2,3)), 0)");
-		expression.Evaluate().Should().Be(3);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(3);
 	}
 
 	[Fact]
 	public void If_ReturningDifferentTypes_HandlesCorrectly()
 	{
 		var expression = new ExtendedExpression("if(true, 123, 'string')");
-		expression.Evaluate().Should().Be(123);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(123);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/InTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/InTests.cs
@@ -11,7 +11,7 @@ public class InTests
 	public void In_UsingInlineData_ResultMatchesExpectation(string stringList, string item, bool expected)
 	{
 		var expression = new ExtendedExpression($"in({item},{stringList})");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(expected);
 	}
 
@@ -40,14 +40,14 @@ public class InTests
 	[InlineData("in(' ', 'a', ' ', 'b')", true)]
 	[InlineData("in(10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)", true)]
 	[InlineData("in(1.5, 0.5, 1.0, 1.5, 2.0)", true)]
-	public void In_VariousScenarios_ReturnsExpected(string expression, bool expected) => new ExtendedExpression(expression).Evaluate().Should().Be(expected);
+	public void In_VariousScenarios_ReturnsExpected(string expression, bool expected) => new ExtendedExpression(expression).Evaluate(TestContext.Current.CancellationToken).Should().Be(expected);
 
 	[Fact]
 	public void In_WithVariable_ReturnsTrue()
 	{
 		var expression = new ExtendedExpression("in(searchValue, 'apple', 'banana', 'cherry')");
 		expression.Parameters["searchValue"] = "banana";
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Theory]
@@ -55,7 +55,7 @@ public class InTests
 	[InlineData("in('single')")]
 	public void In_InvalidParameterCount_ThrowsException(string expression)
 		=> new ExtendedExpression(expression)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*requires at least two parameters*");
@@ -65,14 +65,14 @@ public class InTests
 	public void In_TwoParameters_MinimumValid_Works()
 	{
 		var expression = new ExtendedExpression("in(1, 1)");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void In_ManyParameters_Works()
 	{
 		var expression = new ExtendedExpression("in(100, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 100)");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
@@ -81,34 +81,34 @@ public class InTests
 		// JObjects are compared by reference, not value
 		var expression = new ExtendedExpression("in(searchValue, jObject('a', 2), searchValue)");
 		expression.Parameters["searchValue"] = JObject.Parse("{\"a\": 1}");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void In_WithMixedTypes_Works()
 	{
 		var expression = new ExtendedExpression("in(1, '1', 1.0, 1)");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void In_CaseSensitiveStrings_Works()
 	{
 		var expression = new ExtendedExpression("in('Test', 'test', 'TEST', 'TeSt')");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	[Fact]
 	public void In_WithBooleans_Works()
 	{
 		var expression = new ExtendedExpression("in(false, true, true, false)");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void In_WithDoubles_Works()
 	{
 		var expression = new ExtendedExpression("in(2.5, 1.5, 2.5, 3.5)");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/IndexOfTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/IndexOfTests.cs
@@ -9,7 +9,7 @@ public class IndexOfTests
 	public void IndexOf_InlineData_ResultsMatchExpectation(string list, string item, object expected)
 	{
 		var expr = new ExtendedExpression($"indexOf('{list}','{item}')");
-		var result = expr.Evaluate();
+		var result = expr.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(expected);
 	}
 
@@ -17,20 +17,20 @@ public class IndexOfTests
 	public void IndexOf_NullFirstParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("indexOf(null, 'search')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>();
 	}
 
 	[Fact]
 	public void IndexOf_NullSecondParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("indexOf('string', null)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>();
 	}
 
 	[Fact]
 	public void IndexOf_NonStringParameters_ThrowsException()
 	{
 		var expression = new ExtendedExpression("indexOf(123, 456)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>();
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/InterClassTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/InterClassTests.cs
@@ -6,7 +6,7 @@ public class InterClassTests
 	public void AddingAnIntStringToAnInt_YieldsDouble()
 	{
 		var expression = new ExtendedExpression("0 + '1'");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<double>();
 		result.Should().Be(1);
 	}
@@ -15,7 +15,7 @@ public class InterClassTests
 	public void AddingAnIntToAnIntString_YieldsDouble()
 	{
 		var expression = new ExtendedExpression("'1' + 0");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<double>();
 		result.Should().Be(1);
 	}

--- a/PanoramicData.NCalcExtensions.Test/IsGuidTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/IsGuidTests.cs
@@ -15,7 +15,7 @@ public class IsGuidTests
 	{
 		var expression = new ExtendedExpression("isGuid(parameter1)");
 		expression.Parameters["parameter1"] = parameterValue;
-		(expression.Evaluate() as bool?).Should().Be(expectedResult);
+		(expression.Evaluate(TestContext.Current.CancellationToken) as bool?).Should().Be(expectedResult);
 	}
 
 	[Fact]
@@ -23,14 +23,14 @@ public class IsGuidTests
 	{
 		var expression = new ExtendedExpression("isGuid(parameter1)");
 		expression.Parameters["parameter1"] = Guid.NewGuid();
-		(expression.Evaluate() as bool?).Should().BeTrue();
+		(expression.Evaluate(TestContext.Current.CancellationToken) as bool?).Should().BeTrue();
 	}
 
 	[Fact]
 	public void IsGuid_WrongNumberOfParameters_ThrowsException()
 	{
 		var expression = new ExtendedExpression("isGuid()");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*requires one parameter*");
 	}
 
@@ -38,7 +38,7 @@ public class IsGuidTests
 	public void IsGuid_TooManyParameters_ThrowsException()
 	{
 		var expression = new ExtendedExpression("isGuid('test', 'extra')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*requires one parameter*");
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/IsInfiniteTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/IsInfiniteTests.cs
@@ -17,7 +17,7 @@ public class IsInfiniteTests
 	public void IsInfinite_VariousInputs_ReturnsExpected(string input, bool expected)
 	{
 		var expression = new ExtendedExpression($"isInfinite({input})");
-		expression.Evaluate().Should().Be(expected);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(expected);
 	}
 
 	[Theory]
@@ -26,7 +26,7 @@ public class IsInfiniteTests
 	[InlineData("isInfinite(1, 2, 3)")]
 	public void IsInfinite_WrongParameterCount_ThrowsException(string expressionText)
 		=> new ExtendedExpression(expressionText)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*requires one parameter*");
@@ -40,6 +40,6 @@ public class IsInfiniteTests
 	{
 		var expression = new ExtendedExpression("isInfinite(value)");
 		expression.Parameters["value"] = value;
-		expression.Evaluate().Should().Be(expected);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(expected);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/IsNanTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/IsNanTests.cs
@@ -8,21 +8,21 @@ public class IsNanTests : NCalcTest
 	public void IsNan_Example1_Succeeds()
 	{
 		var expression = new ExtendedExpression("isNaN(1)");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	[Fact]
 	public void IsNan_Example2_Succeeds()
 	{
 		var expression = new ExtendedExpression("isNaN(null)");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void IsNan_Example3_Succeeds()
 	{
 		var expression = new ExtendedExpression("isNaN('text')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	// Additional comprehensive tests
@@ -33,19 +33,19 @@ public class IsNanTests : NCalcTest
 	[InlineData("isNaN(0)", false)]
 	[InlineData("isNaN(-1)", false)]
 	public void IsNaN_NumericValues_ReturnsFalse(string expression, bool expected)
-		=> new ExtendedExpression(expression).Evaluate().Should().Be(expected);
+		=> new ExtendedExpression(expression).Evaluate(TestContext.Current.CancellationToken).Should().Be(expected);
 
 	[Theory]
 	[InlineData("isNaN(1.0 / 0.0)", false)] // Infinity, not NaN
 	[InlineData("isNaN(-1.0 / 0.0)", false)] // Negative infinity, not NaN
 	public void IsNaN_InfinityValues_ReturnsFalse(string expression, bool expected)
-		=> new ExtendedExpression(expression).Evaluate().Should().Be(expected);
+		=> new ExtendedExpression(expression).Evaluate(TestContext.Current.CancellationToken).Should().Be(expected);
 
 	[Fact]
 	public void IsNaN_ActualNaN_ReturnsTrue()
 	{
 		var expression = new ExtendedExpression("isNaN(0.0 / 0.0)");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Theory]
@@ -53,7 +53,7 @@ public class IsNanTests : NCalcTest
 	[InlineData("isNaN(1, 2)")]
 	public void IsNaN_WrongParameterCount_ThrowsException(string expression)
 		=> new ExtendedExpression(expression)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*requires one parameter*");
@@ -66,27 +66,27 @@ public class IsNanTests : NCalcTest
 	public void IsNaN_IntegerTypes_ReturnsFalse(string systemType)
 	{
 		var expression = new ExtendedExpression($"isNaN(cast(1, 'System.{systemType}'))");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	[Fact]
 	public void IsNaN_Float_HandlesCorrectly()
 	{
 		var expression = new ExtendedExpression("isNaN(cast(1.5, 'System.Single'))");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	[Fact]
 	public void IsNaN_Double_HandlesCorrectly()
 	{
 		var expression = new ExtendedExpression("isNaN(1.5)");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	[Fact]
 	public void IsNaN_Decimal_ReturnsFalse()
 	{
 		var expression = new ExtendedExpression("isNaN(cast(1.5, 'System.Decimal'))");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/IsNullOrWhitespaceTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/IsNullOrWhitespaceTests.cs
@@ -10,7 +10,7 @@ public class IsNullOrWhiteSpaceTests
 	[InlineData("null", true)]
 	[InlineData("''", true)]
 	public void IsNullOrWhiteSpace_UsingInlineData_ResultMatchesExpected(string parameter, bool expectedValue)
-		=> new ExtendedExpression($"isNullOrWhiteSpace({parameter})").Evaluate().Should().Be(expectedValue);
+		=> new ExtendedExpression($"isNullOrWhiteSpace({parameter})").Evaluate(TestContext.Current.CancellationToken).Should().Be(expectedValue);
 
 	[Theory]
 	[InlineData("'a', 'a'")]
@@ -18,7 +18,7 @@ public class IsNullOrWhiteSpaceTests
 	[InlineData("'a', null, null")]
 	public void IsNullOrWhiteSpace_UsingAnIncorrectAmountOfParameters_ThrowsException(string parameter)
 		=> new ExtendedExpression($"isNullOrWhiteSpace({parameter})")
-		.Invoking(x => x.Evaluate())
+		.Invoking(x => x.Evaluate(TestContext.Current.CancellationToken))
 		.Should()
 		.Throw<FormatException>().WithMessage("isNullOrWhiteSpace() requires one parameter.");
 
@@ -27,7 +27,7 @@ public class IsNullOrWhiteSpaceTests
 	{
 		var expression = new ExtendedExpression("isNullOrWhiteSpace(value)");
 		expression.Parameters["value"] = JValue.CreateNull();
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
@@ -36,7 +36,7 @@ public class IsNullOrWhiteSpaceTests
 		var jsonDoc = JsonDocument.Parse("{\"value\": \"  \"}");
 		var expression = new ExtendedExpression("isNullOrWhiteSpace(value)");
 		expression.Parameters["value"] = jsonDoc.RootElement.GetProperty("value");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 }
 
@@ -48,7 +48,7 @@ public class IsNullOrEmptyTests
 	[InlineData("null", true)]
 	[InlineData("''", true)]
 	public void IsNullOrEmpty_UsingInlineData_ResultMatchesExpected(string parameter, bool expectedValue)
-		=> new ExtendedExpression($"isNullOrEmpty({parameter})").Evaluate().Should().Be(expectedValue);
+		=> new ExtendedExpression($"isNullOrEmpty({parameter})").Evaluate(TestContext.Current.CancellationToken).Should().Be(expectedValue);
 
 	[Theory]
 	[InlineData("'a', 'a'")]
@@ -56,7 +56,7 @@ public class IsNullOrEmptyTests
 	[InlineData("'a', null, null")]
 	public void IsNullOrEmpty_UsingAnIncorrectAmountOfParameters_ThrowsException(string parameter)
 		=> new ExtendedExpression($"isNullOrEmpty({parameter})")
-		.Invoking(x => x.Evaluate())
+		.Invoking(x => x.Evaluate(TestContext.Current.CancellationToken))
 		.Should()
 		.Throw<FormatException>().WithMessage("isNullOrEmpty() requires one parameter.");
 
@@ -65,7 +65,7 @@ public class IsNullOrEmptyTests
 	{
 		var expression = new ExtendedExpression("isNullOrEmpty(value)");
 		expression.Parameters["value"] = JValue.CreateNull();
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
@@ -74,6 +74,6 @@ public class IsNullOrEmptyTests
 		var jsonDoc = JsonDocument.Parse("{\"value\": \"\"}");
 		var expression = new ExtendedExpression("isNullOrEmpty(value)");
 		expression.Parameters["value"] = jsonDoc.RootElement.GetProperty("value");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/IsNullTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/IsNullTests.cs
@@ -21,7 +21,7 @@ public class IsNullTests
 	public void IsNull_VariousValues_ReturnsExpected(string expression, bool expected)
 	{
 		var extendedExpression = new ExtendedExpression($"isNull({expression})");
-		(extendedExpression.Evaluate() as bool?).Should().Be(expected);
+		(extendedExpression.Evaluate(TestContext.Current.CancellationToken) as bool?).Should().Be(expected);
 	}
 
 	[Fact]
@@ -29,7 +29,7 @@ public class IsNullTests
 	{
 		var expression = new ExtendedExpression("isNull(bob)");
 		expression.Parameters["bob"] = null;
-		(expression.Evaluate() as bool?).Should().BeTrue();
+		(expression.Evaluate(TestContext.Current.CancellationToken) as bool?).Should().BeTrue();
 	}
 
 	[Fact]
@@ -37,7 +37,7 @@ public class IsNullTests
 	{
 		var expression = new ExtendedExpression("isNull(myVar)");
 		expression.Parameters["myVar"] = 42;
-		(expression.Evaluate() as bool?).Should().BeFalse();
+		(expression.Evaluate(TestContext.Current.CancellationToken) as bool?).Should().BeFalse();
 	}
 
 	[Fact]
@@ -47,7 +47,7 @@ public class IsNullTests
 		var jObject = JObject.FromObject(theObject);
 		var expression = new ExtendedExpression($"isNull({nameof(jObject)})");
 		expression.Parameters.Add(nameof(jObject), jObject["InnerException"]);
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		(result as bool?).Should().BeTrue();
 	}
 
@@ -58,7 +58,7 @@ public class IsNullTests
 		using var jsonDocument = JsonSerializer.SerializeToDocument(theObject);
 		var expression = new ExtendedExpression($"isNull({nameof(jsonDocument)})");
 		expression.Parameters.Add(nameof(jsonDocument), jsonDocument.RootElement.GetProperty("InnerException"));
-		(expression.Evaluate() as bool?).Should().BeTrue();
+		(expression.Evaluate(TestContext.Current.CancellationToken) as bool?).Should().BeTrue();
 	}
 
 	[Fact]
@@ -68,7 +68,7 @@ public class IsNullTests
 		var jObject = JObject.FromObject(theObject);
 		var expression = new ExtendedExpression($"isNull({nameof(jObject)})");
 		expression.Parameters.Add(nameof(jObject), jObject["Message"]);
-		(expression.Evaluate() as bool?).Should().BeFalse();
+		(expression.Evaluate(TestContext.Current.CancellationToken) as bool?).Should().BeFalse();
 	}
 
 	[Fact]
@@ -78,7 +78,7 @@ public class IsNullTests
 		using var jsonDocument = JsonSerializer.SerializeToDocument(theObject);
 		var expression = new ExtendedExpression($"isNull({nameof(jsonDocument)})");
 		expression.Parameters.Add(nameof(jsonDocument), jsonDocument.RootElement.GetProperty("Message"));
-		(expression.Evaluate() as bool?).Should().BeFalse();
+		(expression.Evaluate(TestContext.Current.CancellationToken) as bool?).Should().BeFalse();
 	}
 
 	[Fact]
@@ -86,7 +86,7 @@ public class IsNullTests
 	{
 		var expression = new ExtendedExpression("isNull(theValue)");
 		expression.Parameters["theValue"] = new JValue(42);
-		(expression.Evaluate() as bool?).Should().BeFalse();
+		(expression.Evaluate(TestContext.Current.CancellationToken) as bool?).Should().BeFalse();
 	}
 
 	[Fact]
@@ -94,7 +94,7 @@ public class IsNullTests
 	{
 		var expression = new ExtendedExpression("isNull(theValue)");
 		expression.Parameters["theValue"] = JValue.CreateNull();
-		(expression.Evaluate() as bool?).Should().BeTrue();
+		(expression.Evaluate(TestContext.Current.CancellationToken) as bool?).Should().BeTrue();
 	}
 
 	[Theory]
@@ -102,7 +102,7 @@ public class IsNullTests
 	[InlineData("isNull(1, 2)")]
 	[InlineData("isNull(1, 2, 3)")]
 	public void IsNull_WrongParameterCount_ThrowsException(string expression) => new ExtendedExpression(expression)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*requires one parameter*");
 }

--- a/PanoramicData.NCalcExtensions.Test/IsSetTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/IsSetTests.cs
@@ -6,14 +6,14 @@ public class IsSetTests
 	public void IsSet_IsNotSet_ReturnsFalse()
 	{
 		var expression = new ExtendedExpression("isSet('a')");
-		Assert.False(expression.Evaluate() as bool?);
+		Assert.False(expression.Evaluate(TestContext.Current.CancellationToken) as bool?);
 	}
 
 	[Fact]
 	public void IsSet_IsNotSetWithParameterReferenceNotSet_ReturnsTrue()
 	{
 		var expression = new ExtendedExpression("isSet('a') && !isNull(a) && a!=''");
-		Assert.False(expression.Evaluate() as bool?);
+		Assert.False(expression.Evaluate(TestContext.Current.CancellationToken) as bool?);
 	}
 
 	[Fact]
@@ -21,7 +21,7 @@ public class IsSetTests
 	{
 		var expression = new ExtendedExpression("isSet('a.b') && !isNull([a.b]) && [a.b] != '1'");
 		expression.Parameters["a.b"] = "";
-		Assert.True(expression.Evaluate() as bool?);
+		Assert.True(expression.Evaluate(TestContext.Current.CancellationToken) as bool?);
 	}
 
 	[Fact]
@@ -29,7 +29,7 @@ public class IsSetTests
 	{
 		var expression = new ExtendedExpression("isSet('a')");
 		expression.Parameters["a"] = 1;
-		Assert.True(expression.Evaluate() as bool?);
+		Assert.True(expression.Evaluate(TestContext.Current.CancellationToken) as bool?);
 	}
 
 	[Fact]
@@ -37,14 +37,14 @@ public class IsSetTests
 	{
 		var expression = new ExtendedExpression("isSet('a')");
 		expression.Parameters["a"] = null;
-		Assert.True(expression.Evaluate() as bool?);
+		Assert.True(expression.Evaluate(TestContext.Current.CancellationToken) as bool?);
 	}
 
 	[Fact]
 	public void IsSet_WrongNumberOfParameters_ThrowsException()
 	{
 		var expression = new ExtendedExpression("isSet()");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*requires one parameter*");
 	}
 
@@ -52,7 +52,7 @@ public class IsSetTests
 	public void IsSet_TooManyParameters_ThrowsException()
 	{
 		var expression = new ExtendedExpression("isSet('a', 'b')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*requires one parameter*");
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/ItemAtIndexTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/ItemAtIndexTests.cs
@@ -11,30 +11,30 @@ public class ItemAtIndexTests : NCalcTest
 	[InlineData("itemAtIndex('a b c', 'xxx')")]
 	public void ItemAtIndex_InsufficientParameters_ThrowsException(string expression)
 		=> new ExtendedExpression(expression)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<FormatException>();
 
 	[Theory]
 	[InlineData("itemAtIndex(split('a b c', ' '), 1)", "b")]
 	public void ItemAtIndex_ReturnsExpected(string expression, object? expectedOutput)
-		=> new ExtendedExpression(expression).Evaluate().Should().Be(expectedOutput);
+		=> new ExtendedExpression(expression).Evaluate(TestContext.Current.CancellationToken).Should().Be(expectedOutput);
 
 	[Theory]
 	[InlineData("itemAtIndex(list(1, 2, 3, 4, 5), 1)", 2)]
 	public void ItemAtIndexWithListInts_ReturnsExpected(string expression, object? expectedOutput)
-		=> new ExtendedExpression(expression).Evaluate().Should().Be(expectedOutput);
+		=> new ExtendedExpression(expression).Evaluate(TestContext.Current.CancellationToken).Should().Be(expectedOutput);
 
 	[Theory]
 	[InlineData("itemAtIndex(list(1, 2, 3, 4), cast(1, 'System.Int64'))", 2)]
 	public void ItemAtIndexWithInt64IndexValue_ReturnsExpected(string expression, object? expectedOutput)
-		=> new ExtendedExpression(expression).Evaluate().Should().Be(expectedOutput);
+		=> new ExtendedExpression(expression).Evaluate(TestContext.Current.CancellationToken).Should().Be(expectedOutput);
 
 	[Theory]
 	[InlineData($"itemAtIndex(list(1, 2, 3, 4), 2147483648)")]
 	public void ItemAtIndexWithInt64IndexValueTooLarge_ThrowsException(string expression)
 		=> new ExtendedExpression(expression)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<FormatException>();
 
@@ -42,7 +42,7 @@ public class ItemAtIndexTests : NCalcTest
 	public void ItemAtIndexWith2ListsAndMultiply_Succeeds()
 	{
 		var result = new ExtendedExpression("itemAtIndex(list(1,2,3,4),0) * itemAtIndex(list(1,2,3,4),1)")
-			.Evaluate();
+			.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().NotBeNull();
 		result.Should().Be(2);
@@ -52,7 +52,7 @@ public class ItemAtIndexTests : NCalcTest
 	public void ItemAtIndexSelectWithListTable_Succeeds()
 	{
 		var result = new ExtendedExpression("select(list(list(1,2),list(2,3),list(3,4)), 'X', 'itemAtIndex(X,0) * itemAtIndex(X,1)')")
-			.Evaluate();
+			.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().NotBeNull();
 		result.Should().BeEquivalentTo(new List<int> { 2, 6, 12 });
@@ -76,7 +76,7 @@ public class ItemAtIndexTests : NCalcTest
 						cast(itemAtIndex(X,1), \'System.Int32\')
 					'
 				)")
-			.Evaluate();
+			.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().NotBeNull();
 		result.Should().BeEquivalentTo(new List<int> { 2, 6, 12 });
@@ -86,13 +86,13 @@ public class ItemAtIndexTests : NCalcTest
 	public void ItemAtIndexWithJArrayEmptyString_ReturnsString()
 	{
 		var expression = new ExtendedExpression("itemAtIndex(jArray('a', ''), 1)");
-		expression.Evaluate().Should().BeOfType<string>();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeOfType<string>();
 	}
 
 	[Fact]
 	public void ItemAtIndexWithJArrayEmptyString_MatchesEmptyString()
 	{
 		var expression = new ExtendedExpression("itemAtIndex(jArray('a', ''), 1) == ''");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/JArrayTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/JArrayTests.cs
@@ -6,7 +6,7 @@ public class JArrayTests
 	public void JArray_CreatesJArray()
 	{
 		var expression = new ExtendedExpression("jArray(jObject('a', 1, 'b', null), jObject('a', 2, 'b', 'woo'), null)");
-		var result = expression.Evaluate() as JArray;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JArray;
 		result.Should().BeOfType<JArray>();
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
@@ -25,7 +25,7 @@ public class JArrayTests
 	public void JArray_StringParameters_CreatesJArray()
 	{
 		var expression = new ExtendedExpression("jArray('test1', 'test2')");
-		var result = expression.Evaluate() as JArray;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JArray;
 		result.Should().BeOfType<JArray>();
 		result.Should().NotBeNull();
 		result.Should().HaveCount(2);

--- a/PanoramicData.NCalcExtensions.Test/JObjectTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/JObjectTests.cs
@@ -6,7 +6,7 @@ public class JObjectTests
 	public void JObject_CreatesJObject()
 	{
 		var expression = new ExtendedExpression("jObject('a', 1, 'b', null)");
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().BeOfType<JObject>();
 		result.Should().NotBeNull();
 		result.Should().HaveCount(2);
@@ -20,7 +20,7 @@ public class JObjectTests
 	public void JObject_EmptyJObject_Succeeds()
 	{
 		var expression = new ExtendedExpression("jObject()");
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().BeOfType<JObject>();
 		result.Should().NotBeNull();
 		result.Should().HaveCount(0);
@@ -30,7 +30,7 @@ public class JObjectTests
 	public void JObject_OddNumberOfParameters_ThrowsException()
 	{
 		var expression = new ExtendedExpression("jObject('a', 1, 'b')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*even number of parameters*");
 	}
 
@@ -38,7 +38,7 @@ public class JObjectTests
 	public void JObject_NonStringKey_ThrowsException()
 	{
 		var expression = new ExtendedExpression("jObject(123, 'value')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*requires a string key*");
 	}
 
@@ -46,7 +46,7 @@ public class JObjectTests
 	public void JObject_DuplicateKey_ThrowsException()
 	{
 		var expression = new ExtendedExpression("jObject('a', 1, 'a', 2)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*can only define property a once*");
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/JPathTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/JPathTests.cs
@@ -15,7 +15,7 @@ public class JPathTests : NCalcTest
 	{
 		var expression = new ExtendedExpression($"jPath(source, '{path}')");
 		expression.Parameters["source"] = TestJObject;
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(
 			expectedResult,
 			because: "the jPath is valid, present and returns a single result"
@@ -29,7 +29,7 @@ public class JPathTests : NCalcTest
 	{
 		var expression = new ExtendedExpression($"jPath(source, 'kvps[?(@key==\\'{key}\\')].value', true)");
 		expression.Parameters["source"] = TestJObject;
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(expectedValue);
 	}
 
@@ -38,7 +38,7 @@ public class JPathTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("jPath(source, 'name')");
 		expression.Parameters["source"] = "SomeRandomString";
-		_ = expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>();
+		_ = expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>();
 	}
 
 	[Fact]
@@ -46,7 +46,7 @@ public class JPathTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("jPath(source, 'name')");
 		expression.Parameters["source"] = new Organization { Name = "woo" };
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be("woo");
 	}
 
@@ -55,7 +55,7 @@ public class JPathTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("jPath(source, 'kvps')");
 		expression.Parameters["source"] = TestJObject;
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<JArray>();
 	}
 
@@ -64,7 +64,7 @@ public class JPathTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("jPath(source, 'name') == 'bob'");
 		expression.Parameters["source"] = JObject.FromObject(new Organization { Name = "bob" });
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<bool>();
 		result.Should().Be(true);
 	}
@@ -75,7 +75,7 @@ public class JPathTests : NCalcTest
 		var expression = new ExtendedExpression("jPath(source, 'size')");
 		expression.Parameters["source"] = JObject.Parse("{ \"name\": \"bob\", \"numbers\": [1, 2] }");
 		expression
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<NCalcExtensionsException>()
 			.WithMessage(
@@ -89,7 +89,7 @@ public class JPathTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("jPath(source, 'size', True)");
 		expression.Parameters["source"] = JObject.Parse("{ \"name\": \"bob\", \"numbers\": [1, 2] }");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeNull(
 			because: "the requested jPath is not present and the third parameter 'returnNullIfNotFound' is set to True"
 		);
@@ -100,7 +100,7 @@ public class JPathTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("jPath(source, 'numbers')");
 		expression.Parameters["source"] = JObject.Parse("{ \"name\": \"bob\", \"numbers\": [1, 2] }");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<JArray>();
 		var theArray = result as JArray;
 		theArray.Should().NotBeNull();

--- a/PanoramicData.NCalcExtensions.Test/JValueUnwrappingTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/JValueUnwrappingTests.cs
@@ -14,21 +14,21 @@ public class JValueUnwrappingTests
 	public void ItemAtIndex_JArrayWithEmptyString_ReturnsString()
 	{
 		var expression = new ExtendedExpression("itemAtIndex(jArray('a', ''), 1)");
-		expression.Evaluate().Should().BeOfType<string>();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeOfType<string>();
 	}
 
 	[Fact]
 	public void ItemAtIndex_JArrayWithEmptyString_EqualsEmptyString()
 	{
 		var expression = new ExtendedExpression("itemAtIndex(jArray('a', ''), 1) == ''");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void ItemAtIndex_JArrayWithString_ReturnsString()
 	{
 		var expression = new ExtendedExpression("itemAtIndex(jArray('hello', 'world'), 0)");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<string>();
 		result.Should().Be("hello");
 	}
@@ -37,7 +37,7 @@ public class JValueUnwrappingTests
 	public void ItemAtIndex_JArrayWithNumber_ReturnsNumber()
 	{
 		var expression = new ExtendedExpression("itemAtIndex(jArray(1, 2, 3), 1)");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<int>(); // JSON integers are deserialized as int
 		result.Should().Be(2);
 	}
@@ -46,14 +46,14 @@ public class JValueUnwrappingTests
 	public void ItemAtIndex_JArrayWithNull_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("itemAtIndex(jArray('a', null, 'c'), 1)");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void ItemAtIndex_JArrayWithBoolean_ReturnsBoolean()
 	{
 		var expression = new ExtendedExpression("itemAtIndex(jArray(true, false), 0)");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<bool>();
 		result.Should().Be(true);
 	}
@@ -66,7 +66,7 @@ public class JValueUnwrappingTests
 	public void First_JArrayWithStrings_ReturnsString()
 	{
 		var expression = new ExtendedExpression("first(jArray('a', 'b', 'c'))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<string>();
 		result.Should().Be("a");
 	}
@@ -75,14 +75,14 @@ public class JValueUnwrappingTests
 	public void First_JArrayWithEmptyString_ReturnsEmptyString()
 	{
 		var expression = new ExtendedExpression("first(jArray('', 'b'))");
-		expression.Evaluate().Should().Be("");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("");
 	}
 
 	[Fact]
 	public void First_JArrayWithLambda_ReturnsUnwrappedValue()
 	{
 		var expression = new ExtendedExpression("first(jArray(1, 2, 3, 4), 'n', 'n > 2')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<int>();
 		result.Should().Be(3);
 	}
@@ -91,7 +91,7 @@ public class JValueUnwrappingTests
 	public void FirstOrDefault_JArrayWithStrings_ReturnsString()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(jArray('x', 'y'))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<string>();
 		result.Should().Be("x");
 	}
@@ -100,14 +100,14 @@ public class JValueUnwrappingTests
 	public void FirstOrDefault_JArrayNoMatch_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(jArray(1, 2, 3), 'n', 'n > 10')");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void FirstOrDefault_EmptyJArray_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("firstOrDefault(jArray())");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	#endregion
@@ -118,7 +118,7 @@ public class JValueUnwrappingTests
 	public void Last_JArrayWithStrings_ReturnsString()
 	{
 		var expression = new ExtendedExpression("last(jArray('a', 'b', 'c'))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<string>();
 		result.Should().Be("c");
 	}
@@ -127,14 +127,14 @@ public class JValueUnwrappingTests
 	public void Last_JArrayWithEmptyString_ReturnsEmptyString()
 	{
 		var expression = new ExtendedExpression("last(jArray('a', ''))");
-		expression.Evaluate().Should().Be("");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("");
 	}
 
 	[Fact]
 	public void Last_JArrayWithLambda_ReturnsUnwrappedValue()
 	{
 		var expression = new ExtendedExpression("last(jArray(1, 2, 3, 4, 2), 'n', 'n == 2')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<int>();
 		result.Should().Be(2);
 	}
@@ -143,7 +143,7 @@ public class JValueUnwrappingTests
 	public void LastOrDefault_JArrayWithStrings_ReturnsString()
 	{
 		var expression = new ExtendedExpression("lastOrDefault(jArray('x', 'y', 'z'))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<string>();
 		result.Should().Be("z");
 	}
@@ -152,14 +152,14 @@ public class JValueUnwrappingTests
 	public void LastOrDefault_JArrayNoMatch_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("lastOrDefault(jArray(1, 2, 3), 'n', 'n > 10')");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void LastOrDefault_EmptyJArray_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("lastOrDefault(jArray())");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	#endregion
@@ -170,7 +170,7 @@ public class JValueUnwrappingTests
 	public void Select_JArrayWithStrings_ReturnsListOfStrings()
 	{
 		var expression = new ExtendedExpression("select(jArray('a', 'b', 'c'), 's', 's')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 		result.Should().AllBeOfType<string>();
@@ -180,7 +180,7 @@ public class JValueUnwrappingTests
 	public void Select_JArrayWithEmptyStrings_ReturnsEmptyStrings()
 	{
 		var expression = new ExtendedExpression("select(jArray('a', '', 'c'), 's', 's')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result![1].Should().Be("");
 	}
@@ -189,7 +189,7 @@ public class JValueUnwrappingTests
 	public void Select_JArrayWithNumbers_ReturnsNumbers()
 	{
 		var expression = new ExtendedExpression("select(jArray(1, 2, 3), 'n', 'n')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 		result![0].Should().Be(1L);
@@ -200,7 +200,7 @@ public class JValueUnwrappingTests
 	public void Select_JArrayWithLambdaReturningString_ReturnsStrings()
 	{
 		var expression = new ExtendedExpression("select(jArray(1, 2, 3), 'n', 'toString(n)')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().AllBeOfType<string>();
 	}
@@ -209,7 +209,7 @@ public class JValueUnwrappingTests
 	public void Select_JArrayItemsInLambda_ReturnsUnwrappedValues()
 	{
 		var expression = new ExtendedExpression("select(jArray('a', 'b'), 's', 'toUpper(s)')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().BeEquivalentTo(new[] { "A", "B" });
 	}
@@ -222,7 +222,7 @@ public class JValueUnwrappingTests
 	public void Min_JArrayOfNumbers_ReturnsNumber()
 	{
 		var expression = new ExtendedExpression("min(jArray(3, 1, 4, 1, 5))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(1);
 	}
 
@@ -230,7 +230,7 @@ public class JValueUnwrappingTests
 	public void Min_JArrayOfStrings_ReturnsString()
 	{
 		var expression = new ExtendedExpression("min(jArray('zebra', 'apple', 'banana'))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<string>();
 		result.Should().Be("apple");
 	}
@@ -239,7 +239,7 @@ public class JValueUnwrappingTests
 	public void Max_JArrayOfNumbers_ReturnsNumber()
 	{
 		var expression = new ExtendedExpression("max(jArray(3, 1, 4, 1, 5))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(5);
 	}
 
@@ -247,7 +247,7 @@ public class JValueUnwrappingTests
 	public void Max_JArrayOfStrings_ReturnsString()
 	{
 		var expression = new ExtendedExpression("max(jArray('zebra', 'apple', 'banana'))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<string>();
 		result.Should().Be("zebra");
 	}
@@ -256,7 +256,7 @@ public class JValueUnwrappingTests
 	public void Min_JArrayWithLambda_ReturnsCorrectValue()
 	{
 		var expression = new ExtendedExpression("min(jArray(5, 3, 8, 1), 'n', 'n * 2')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(2); // 1 * 2 = 2
 	}
 
@@ -264,7 +264,7 @@ public class JValueUnwrappingTests
 	public void Max_JArrayWithLambda_ReturnsCorrectValue()
 	{
 		var expression = new ExtendedExpression("max(jArray(5, 3, 8, 1), 'n', 'n * 2')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(16); // 8 * 2 = 16
 	}
 
@@ -276,7 +276,7 @@ public class JValueUnwrappingTests
 	public void Where_JArray_ReturnsListWithUnwrappedValues()
 	{
 		var expression = new ExtendedExpression("where(jArray(1, 2, 3, 4, 5), 'n', 'n > 2')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().BeEquivalentTo(new object[] { 3L, 4L, 5L });
 	}
@@ -285,7 +285,7 @@ public class JValueUnwrappingTests
 	public void Where_JArrayOfStrings_ReturnsStrings()
 	{
 		var expression = new ExtendedExpression("where(jArray('apple', 'banana', 'apricot'), 's', 'startsWith(s, \"a\")')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().AllBeOfType<string>();
 		result.Should().HaveCount(2);
@@ -295,7 +295,7 @@ public class JValueUnwrappingTests
 	public void Where_JArrayWithEmptyString_PreservesEmptyString()
 	{
 		var expression = new ExtendedExpression("where(jArray('a', '', 'c'), 's', 's != null')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 		result![1].Should().Be("");
@@ -309,28 +309,28 @@ public class JValueUnwrappingTests
 	public void All_JArrayOfBooleans_ReturnsCorrectResult()
 	{
 		var expression = new ExtendedExpression("all(jArray(true, true, true))");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void All_JArrayWithLambda_WorksCorrectly()
 	{
 		var expression = new ExtendedExpression("all(jArray(2, 4, 6), 'n', 'n % 2 == 0')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void Any_JArrayOfNumbers_WorksCorrectly()
 	{
 		var expression = new ExtendedExpression("any(jArray(1, 3, 5, 6), 'n', 'n % 2 == 0')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void Any_JArrayOfStrings_WorksCorrectly()
 	{
 		var expression = new ExtendedExpression("any(jArray('cat', 'dog', 'bird'), 's', 'startsWith(s, \"d\")')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	#endregion
@@ -341,14 +341,14 @@ public class JValueUnwrappingTests
 	public void Count_JArray_ReturnsCorrectCount()
 	{
 		var expression = new ExtendedExpression("count(jArray(1, 2, 3, 4, 5))");
-		expression.Evaluate().Should().Be(5);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(5);
 	}
 
 	[Fact]
 	public void Count_JArrayWithLambda_ReturnsCorrectCount()
 	{
 		var expression = new ExtendedExpression("count(jArray(1, 2, 3, 4, 5), 'n', 'n > 3')");
-		expression.Evaluate().Should().Be(2);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(2);
 	}
 
 	#endregion
@@ -359,7 +359,7 @@ public class JValueUnwrappingTests
 	public void SelectDistinct_JArray_ReturnsUnwrappedValues()
 	{
 		var expression = new ExtendedExpression("selectDistinct(jArray(1, 2, 2, 3), 'n', 'n')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().BeEquivalentTo(new object[] { 1L, 2L, 3L });
 	}
@@ -368,7 +368,7 @@ public class JValueUnwrappingTests
 	public void SelectDistinct_JArrayOfStrings_ReturnsStrings()
 	{
 		var expression = new ExtendedExpression("selectDistinct(jArray('a', 'b', 'a', 'c'), 's', 's')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().AllBeOfType<string>();
 		result.Should().BeEquivalentTo(new[] { "a", "b", "c" });
@@ -382,7 +382,7 @@ public class JValueUnwrappingTests
 	public void OrderBy_JArrayOfNumbers_ReturnsUnwrappedValues()
 	{
 		var expression = new ExtendedExpression("orderBy(jArray(3, 1, 4, 1, 5), 'n', 'n')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().BeEquivalentTo(new object[] { 1L, 1L, 3L, 4L, 5L }, options => options.WithStrictOrdering());
 	}
@@ -391,7 +391,7 @@ public class JValueUnwrappingTests
 	public void OrderBy_JArrayOfStrings_ReturnsStrings()
 	{
 		var expression = new ExtendedExpression("orderBy(jArray('zebra', 'apple', 'banana'), 's', 's')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().AllBeOfType<string>();
 		result.Should().BeEquivalentTo(new[] { "apple", "banana", "zebra" }, options => options.WithStrictOrdering());
@@ -405,7 +405,7 @@ public class JValueUnwrappingTests
 	public void Sum_JArrayOfNumbers_ReturnsCorrectSum()
 	{
 		var expression = new ExtendedExpression("sum(jArray(1, 2, 3, 4, 5))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		// Sum handles JValues internally
 		result.Should().Be(15.0); // GetSum returns double
 	}
@@ -414,7 +414,7 @@ public class JValueUnwrappingTests
 	public void Sum_JArrayWithLambda_ReturnsCorrectSum()
 	{
 		var expression = new ExtendedExpression("sum(jArray(1, 2, 3), 'n', 'n * 2')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<double>();
 		result.Should().Be(12.0); // (1*2) + (2*2) + (3*2) = 12
 	}
@@ -438,7 +438,7 @@ public class JValueUnwrappingTests
 					'n'
 				)
 			)");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(6); // First value after filtering (2*3=6) and ordering
 	}
 
@@ -446,7 +446,7 @@ public class JValueUnwrappingTests
 	public void ItemAtIndex_WithSelect_ReturnsUnwrappedValue()
 	{
 		var expression = new ExtendedExpression("itemAtIndex(select(jArray('a', 'b', 'c'), 's', 's'), 1)");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<string>();
 		result.Should().Be("b");
 	}
@@ -462,7 +462,7 @@ public class JValueUnwrappingTests
 				),
 				0
 			)");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<JObject>();
 	}
 
@@ -470,7 +470,7 @@ public class JValueUnwrappingTests
 	public void MixedTypes_JArray_HandlesCorrectly()
 	{
 		var expression = new ExtendedExpression("select(jArray(1, 'two', 3.0, true), 'x', 'toString(x)')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().AllBeOfType<string>();
 		result.Should().HaveCount(4);
@@ -492,28 +492,28 @@ public class JValueUnwrappingTests
 				),
 				0
 			)");
-		expression.Evaluate().Should().Be("");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("");
 	}
 
 	[Fact]
 	public void StringComparison_WithJArrayElements_Works()
 	{
 		var expression = new ExtendedExpression("first(jArray('test', 'value')) == 'test'");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void NumericComparison_WithJArrayElements_Works()
 	{
 		var expression = new ExtendedExpression("first(jArray(42, 100)) > 40");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void NullHandling_ThroughOperations_WorksCorrectly()
 	{
 		var expression = new ExtendedExpression("count(where(jArray(1, null, 3, null, 5), 'n', 'n != null'))");
-		expression.Evaluate().Should().Be(3);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(3);
 	}
 
 	#endregion

--- a/PanoramicData.NCalcExtensions.Test/JoinTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/JoinTests.cs
@@ -9,7 +9,7 @@ public class JoinTests : NCalcTest
 	public void Join_Simple_Succeeds()
 	{
 		var expression = new ExtendedExpression("join(list('a', 'b', 'c'), ', ')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<string>();
 		result.Should().Be("a, b, c");
 	}
@@ -18,7 +18,7 @@ public class JoinTests : NCalcTest
 	public void Join_ContainingNulls_Succeeds()
 	{
 		var expression = new ExtendedExpression("join(list('a', null, 'c'), ',')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<string>();
 		result.Should().Be("a,,c");
 	}
@@ -28,7 +28,7 @@ public class JoinTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("join(array, ', ')");
 		expression.Parameters["array"] = new[] { "a", "b", "c" };
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<string>();
 		result.Should().Be("a, b, c");
 	}
@@ -38,7 +38,7 @@ public class JoinTests : NCalcTest
 	[InlineData("join(1)")]
 	public void Join_InsufficientParameters_ThrowsException(string expression)
 		=> new ExtendedExpression(expression)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<FormatException>();
 
@@ -47,56 +47,56 @@ public class JoinTests : NCalcTest
 	[InlineData("join(split('a b c', ' '), ', ')", "a, b, c")]
 	[InlineData("join(list('a', 'b', 'c'), ', ')", "a, b, c")]
 	public void Switch_ReturnsExpected(string expression, object? expectedOutput)
-		=> new ExtendedExpression(expression).Evaluate().Should().Be(expectedOutput);
+		=> new ExtendedExpression(expression).Evaluate(TestContext.Current.CancellationToken).Should().Be(expectedOutput);
 
 		// Additional comprehensive tests
 		[Fact]
 		public void Join_EmptyList_ReturnsEmpty()
 		{
 			var expression = new ExtendedExpression("join(list(), ',')");
-			expression.Evaluate().Should().Be("");
+			expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("");
 		}
 
 		[Fact]
 		public void Join_SingleItem_ReturnsItem()
 		{
 			var expression = new ExtendedExpression("join(list('single'), ',')");
-			expression.Evaluate().Should().Be("single");
+			expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("single");
 		}
 
 		[Fact]
 		public void Join_TwoItems_JoinsProperly()
 		{
 			var expression = new ExtendedExpression("join(list('first', 'second'), ' | ')");
-			expression.Evaluate().Should().Be("first | second");
+			expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("first | second");
 		}
 
 		[Fact]
 		public void Join_Numbers_ConvertsToStrings()
 		{
 			var expression = new ExtendedExpression("join(list(1, 2, 3), ',')");
-			expression.Evaluate().Should().Be("1,2,3");
+			expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("1,2,3");
 		}
 
 		[Fact]
 		public void Join_MixedTypes_ConvertsToStrings()
 		{
 			var expression = new ExtendedExpression("join(list('a', 1, true, 3.14), ' - ')");
-			expression.Evaluate().Should().Be("a - 1 - True - 3.14");
+			expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("a - 1 - True - 3.14");
 		}
 
 		[Fact]
 		public void Join_WithEmptyStringSeparator_Concatenates()
 		{
 			var expression = new ExtendedExpression("join(list('a', 'b', 'c'), '')");
-			expression.Evaluate().Should().Be("abc");
+			expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("abc");
 		}
 
 		[Fact]
 		public void Join_WithMultiCharSeparator_Works()
 		{
 			var expression = new ExtendedExpression("join(list('a', 'b', 'c'), ' :: ')");
-			expression.Evaluate().Should().Be("a :: b :: c");
+			expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("a :: b :: c");
 		}
 
 		[Fact]
@@ -104,7 +104,7 @@ public class JoinTests : NCalcTest
 		{
 			var expression = new ExtendedExpression("join(list('line1', 'line2', 'line3'), '\\n')");
 			// Use escaped backslash-n in expression, not actual newline
-			var result = expression.Evaluate() as string;
+			var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 			result.Should().NotBeNull();
 			// The result will have literal \n, not newline character
 			result.Should().Contain("line1");
@@ -114,35 +114,35 @@ public class JoinTests : NCalcTest
 		public void Join_AllNulls_ReturnsEmptyWithSeparators()
 		{
 			var expression = new ExtendedExpression("join(list(null, null, null), ',')");
-			expression.Evaluate().Should().Be(",,");
+			expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(",,");
 		}
 
 		[Fact]
 		public void Join_EmptyStringsInList_Preserves()
 		{
 			var expression = new ExtendedExpression("join(list('', 'b', ''), ',')");
-			expression.Evaluate().Should().Be(",b,");
+			expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(",b,");
 		}
 
 		[Fact]
 		public void Join_WithSpaceSeparator_Works()
 		{
 			var expression = new ExtendedExpression("join(list('hello', 'world'), ' ')");
-			expression.Evaluate().Should().Be("hello world");
+			expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("hello world");
 		}
 
 		[Fact]
 		public void Join_LongList_Works()
 		{
 			var expression = new ExtendedExpression("join(list('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'), '-')");
-			expression.Evaluate().Should().Be("a-b-c-d-e-f-g-h");
+			expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("a-b-c-d-e-f-g-h");
 		}
 
 		[Fact]
 		public void Join_WithBooleans_ConvertsToString()
 		{
 			var expression = new ExtendedExpression("join(list(true, false, true), ',')");
-			expression.Evaluate().Should().Be("True,False,True");
+			expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("True,False,True");
 		}
 
 		[Fact]
@@ -151,7 +151,7 @@ public class JoinTests : NCalcTest
 			var expression = new ExtendedExpression("join(myList, mySeparator)");
 			expression.Parameters["myList"] = new[] { "x", "y", "z" };
 			expression.Parameters["mySeparator"] = " | ";
-			expression.Evaluate().Should().Be("x | y | z");
+			expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("x | y | z");
 		}
 
 		[Fact]
@@ -160,7 +160,7 @@ public class JoinTests : NCalcTest
 			var expression = new ExtendedExpression("join(myList, ',')");
 			expression.Parameters["myList"] = new List<int> { 10, 20, 30 };
 			// Join expects IEnumerable<string> or List<object>, not List<int>
-			expression.Invoking(e => e.Evaluate())
+			expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 				.Should().Throw<FormatException>();
 		}
 
@@ -169,35 +169,35 @@ public class JoinTests : NCalcTest
 		{
 			var expression = new ExtendedExpression("join(myList, ' ')");
 			expression.Parameters["myList"] = new List<string> { "one", "two", "three" };
-			expression.Evaluate().Should().Be("one two three");
+			expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("one two three");
 		}
 
 		[Fact]
 		public void Join_SpecialCharactersInItems_Preserves()
 		{
 			var expression = new ExtendedExpression("join(list('a@b', 'c#d', 'e$f'), ',')");
-			expression.Evaluate().Should().Be("a@b,c#d,e$f");
+			expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("a@b,c#d,e$f");
 		}
 
 		[Fact]
 		public void Join_WithTabSeparator_Works()
 		{
 			var expression = new ExtendedExpression("join(list('col1', 'col2', 'col3'), '\t')");
-			expression.Evaluate().Should().Be("col1\tcol2\tcol3");
+			expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("col1\tcol2\tcol3");
 		}
 
 		[Fact]
 		public void Join_ChainedWithOtherFunctions_Works()
 		{
 			var expression = new ExtendedExpression("join(select(list(1, 2, 3), 'n', 'n * 2'), ', ')");
-			expression.Evaluate().Should().Be("2, 4, 6");
+			expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("2, 4, 6");
 		}
 
 		[Fact]
 		public void Join_WithDistinct_Works()
 		{
 			var expression = new ExtendedExpression("join(distinct(list('a', 'b', 'a', 'c', 'b')), ',')");
-			expression.Evaluate().Should().Be("a,b,c");
+			expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("a,b,c");
 		}
 
 		// Error cases
@@ -206,14 +206,14 @@ public class JoinTests : NCalcTest
 		{
 			var expression = new ExtendedExpression("join(null, ',')");
 			// Join handles null by creating empty list
-			expression.Evaluate().Should().Be("");
+			expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("");
 		}
 
 		[Fact]
 		public void Join_NonEnumerableFirstParam_ThrowsException()
 		{
 			var expression = new ExtendedExpression("join(42, ',')");
-			expression.Invoking(e => e.Evaluate())
+			expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 				.Should().Throw<FormatException>();
 		}
 
@@ -221,7 +221,7 @@ public class JoinTests : NCalcTest
 		public void Join_NonStringSeparator_ThrowsException()
 		{
 			var expression = new ExtendedExpression("join(list('a', 'b'), 123)");
-			expression.Invoking(e => e.Evaluate())
+			expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 				.Should().Throw<FormatException>();
 		}
 
@@ -229,7 +229,7 @@ public class JoinTests : NCalcTest
 		public void Join_NullSeparator_ThrowsException()
 		{
 			var expression = new ExtendedExpression("join(list('a', 'b'), null)");
-			expression.Invoking(e => e.Evaluate())
+			expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 				.Should().Throw<FormatException>();
 		}
 	}

--- a/PanoramicData.NCalcExtensions.Test/JsonArrayTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/JsonArrayTests.cs
@@ -9,7 +9,7 @@ public class JsonArrayTests
 	public void JsonArray_CreatesJsonArray()
 	{
 		var expression = new ExtendedExpression("jsonArray(1, 'test', null, true)");
-		var result = expression.Evaluate() as JsonDocument;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JsonDocument;
 		result.Should().BeOfType<JsonDocument>();
 		result.Should().NotBeNull();
 		result!.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
@@ -26,7 +26,7 @@ public class JsonArrayTests
 	public void JsonArray_EmptyArray_CreatesEmptyJsonArray()
 	{
 		var expression = new ExtendedExpression("jsonArray()");
-		var result = expression.Evaluate() as JsonDocument;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JsonDocument;
 		result.Should().BeOfType<JsonDocument>();
 		result.Should().NotBeNull();
 		result!.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
@@ -37,7 +37,7 @@ public class JsonArrayTests
 	public void JsonArray_NestedObjects_CreatesComplexArray()
 	{
 		var expression = new ExtendedExpression("jsonArray(jsonDocument('a', 1), jsonDocument('b', 2))");
-		var result = expression.Evaluate() as JsonDocument;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JsonDocument;
 		result.Should().BeOfType<JsonDocument>();
 		result.Should().NotBeNull();
 		result!.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
@@ -52,7 +52,7 @@ public class JsonArrayTests
 	public void JsonArray_StringParameters_CreatesJsonArray()
 	{
 		var expression = new ExtendedExpression("jsonArray('test1', 'test2')");
-		var result = expression.Evaluate() as JsonDocument;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JsonDocument;
 		result.Should().BeOfType<JsonDocument>();
 		result.Should().NotBeNull();
 		result!.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
@@ -67,7 +67,7 @@ public class JsonArrayTests
 	public void JsonArray_MixedTypes_CreatesJsonArray()
 	{
 		var expression = new ExtendedExpression("jsonArray(jsonDocument('a', 1, 'b', null), jsonDocument('a', 2, 'b', 'woo'), null)");
-		var result = expression.Evaluate() as JsonDocument;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JsonDocument;
 		result.Should().BeOfType<JsonDocument>();
 		result.Should().NotBeNull();
 		result!.RootElement.ValueKind.Should().Be(JsonValueKind.Array);

--- a/PanoramicData.NCalcExtensions.Test/JsonDocumentIntegrationTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/JsonDocumentIntegrationTests.cs
@@ -21,7 +21,7 @@ public class JsonDocumentIntegrationTests
 			)
 		");
 
-		var result = expression.Evaluate() as JsonDocument;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JsonDocument;
 		result.Should().NotBeNull();
 		result!.RootElement.ValueKind.Should().Be(JsonValueKind.Object);
 
@@ -39,7 +39,7 @@ public class JsonDocumentIntegrationTests
 	{
 		// Test integration between jsonDocument creation and getProperty
 		var expression = new ExtendedExpression("getProperty(jsonDocument('data', jsonDocument('nested', 'value')), 'data')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<JsonElement>();
 
 		var jsonElement = (JsonElement)result;
@@ -51,7 +51,7 @@ public class JsonDocumentIntegrationTests
 	{
 		// Test integration between jsonDocument creation and getProperties
 		var expression = new ExtendedExpression("getProperties(jsonDocument('name', 'test', 'age', 30, 'active', true))");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 		result.Should().Contain("name");
@@ -64,7 +64,7 @@ public class JsonDocumentIntegrationTests
 	{
 		// Test that parsing JSON strings creates compatible JsonDocuments
 		var expression = new ExtendedExpression("getProperty(parse('JsonDocument', '{\"key\": \"value\", \"number\": 42}'), 'key')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be("value");
 	}
 
@@ -73,7 +73,7 @@ public class JsonDocumentIntegrationTests
 	{
 		// Test array parsing and access
 		var expression = new ExtendedExpression("parse('JsonArray', '[{\"name\": \"item1\"}, {\"name\": \"item2\"}]')");
-		var result = expression.Evaluate() as JsonDocument;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JsonDocument;
 		result.Should().NotBeNull();
 		result!.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
 		result.RootElement.GetArrayLength().Should().Be(2);
@@ -84,15 +84,15 @@ public class JsonDocumentIntegrationTests
 	{
 		// Test that null values are handled correctly across different functions
 		var expression1 = new ExtendedExpression("isNull(getProperty(jsonDocument('nullValue', null), 'nullValue'))");
-		var result1 = expression1.Evaluate();
+		var result1 = expression1.Evaluate(TestContext.Current.CancellationToken);
 		result1.Should().Be(true);
 
 		var expression2 = new ExtendedExpression("isNullOrEmpty(getProperty(jsonDocument('emptyString', ''), 'emptyString'))");
-		var result2 = expression2.Evaluate();
+		var result2 = expression2.Evaluate(TestContext.Current.CancellationToken);
 		result2.Should().Be(true);
 
 		var expression3 = new ExtendedExpression("isNullOrWhiteSpace(getProperty(jsonDocument('whitespace', '   '), 'whitespace'))");
-		var result3 = expression3.Evaluate();
+		var result3 = expression3.Evaluate(TestContext.Current.CancellationToken);
 		result3.Should().Be(true);
 	}
 
@@ -104,22 +104,22 @@ public class JsonDocumentIntegrationTests
 
 		var expression1 = new ExtendedExpression("getProperty(source, 'string')");
 		expression1.Parameters["source"] = jsonDoc;
-		var result1 = expression1.Evaluate();
+		var result1 = expression1.Evaluate(TestContext.Current.CancellationToken);
 		result1.Should().Be("text");
 
 		var expression2 = new ExtendedExpression("getProperty(source, 'number')");
 		expression2.Parameters["source"] = jsonDoc;
-		var result2 = expression2.Evaluate();
+		var result2 = expression2.Evaluate(TestContext.Current.CancellationToken);
 		result2.Should().Be(42);
 
 		var expression3 = new ExtendedExpression("getProperty(source, 'boolean')");
 		expression3.Parameters["source"] = jsonDoc;
-		var result3 = expression3.Evaluate();
+		var result3 = expression3.Evaluate(TestContext.Current.CancellationToken);
 		result3.Should().Be(true);
 
 		var expression4 = new ExtendedExpression("getProperty(source, 'null')");
 		expression4.Parameters["source"] = jsonDoc;
-		var result4 = expression4.Evaluate();
+		var result4 = expression4.Evaluate(TestContext.Current.CancellationToken);
 		result4.Should().BeNull();
 	}
 
@@ -129,12 +129,12 @@ public class JsonDocumentIntegrationTests
 		// Test that JsonDocument and JObject can work together in expressions
 		var expression = new ExtendedExpression("toString(typeOf(jsonDoc))");
 		expression.Parameters["jsonDoc"] = JsonDocument.Parse("{\"test\": \"value\"}");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be("JsonDocument");
 
 		var expression2 = new ExtendedExpression("toString(typeOf(jObj))");
 		expression2.Parameters["jObj"] = JObject.Parse("{\"test\": \"value\"}");
-		var result2 = expression2.Evaluate();
+		var result2 = expression2.Evaluate(TestContext.Current.CancellationToken);
 		result2.Should().Be("JObject");
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/JsonDocumentPropertyTypeTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/JsonDocumentPropertyTypeTests.cs
@@ -13,28 +13,28 @@ public class JsonDocumentPropertyTypeTests
 		// Test integer property
 		var expression1 = new ExtendedExpression("getProperty(source, 'intValue')");
 		expression1.Parameters["source"] = jsonDoc;
-		var result1 = expression1.Evaluate();
+		var result1 = expression1.Evaluate(TestContext.Current.CancellationToken);
 		result1.Should().BeOfType<int>();
 		result1.Should().Be(42);
 
 		// Test string property
 		var expression2 = new ExtendedExpression("getProperty(source, 'stringValue')");
 		expression2.Parameters["source"] = jsonDoc;
-		var result2 = expression2.Evaluate();
+		var result2 = expression2.Evaluate(TestContext.Current.CancellationToken);
 		result2.Should().BeOfType<string>();
 		result2.Should().Be("test");
 
 		// Test boolean property
 		var expression3 = new ExtendedExpression("getProperty(source, 'boolValue')");
 		expression3.Parameters["source"] = jsonDoc;
-		var result3 = expression3.Evaluate();
+		var result3 = expression3.Evaluate(TestContext.Current.CancellationToken);
 		result3.Should().BeOfType<bool>();
 		result3.Should().Be(true);
 
 		// Test null property
 		var expression4 = new ExtendedExpression("getProperty(source, 'nullValue')");
 		expression4.Parameters["source"] = jsonDoc;
-		var result4 = expression4.Evaluate();
+		var result4 = expression4.Evaluate(TestContext.Current.CancellationToken);
 		result4.Should().BeNull();
 	}
 
@@ -47,11 +47,11 @@ public class JsonDocumentPropertyTypeTests
 
 		var jsonDocExpression = new ExtendedExpression("getProperty(source, 'value')");
 		jsonDocExpression.Parameters["source"] = jsonDoc;
-		var jsonDocResult = jsonDocExpression.Evaluate();
+		var jsonDocResult = jsonDocExpression.Evaluate(TestContext.Current.CancellationToken);
 
 		var jObjectExpression = new ExtendedExpression("getProperty(source, 'value')");
 		jObjectExpression.Parameters["source"] = jObject;
-		var jObjectResult = jObjectExpression.Evaluate();
+		var jObjectResult = jObjectExpression.Evaluate(TestContext.Current.CancellationToken);
 
 		// Both should return the same type and value
 		jsonDocResult.Should().BeOfType<int>();

--- a/PanoramicData.NCalcExtensions.Test/JsonDocumentTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/JsonDocumentTests.cs
@@ -8,7 +8,7 @@ public class JsonDocumentTests
 	public void JsonDocument_CreatesJsonDocument()
 	{
 		var expression = new ExtendedExpression("jsonDocument('a', 1, 'b', null)");
-		var result = expression.Evaluate() as JsonDocument;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JsonDocument;
 		result.Should().BeOfType<JsonDocument>();
 		result.Should().NotBeNull();
 		result.RootElement.EnumerateObject().Should().HaveCount(2);
@@ -22,7 +22,7 @@ public class JsonDocumentTests
 	public void JsonDocument_EmptyJsonDocument_Succeeds()
 	{
 		var expression = new ExtendedExpression("jsonDocument()");
-		var result = expression.Evaluate() as JsonDocument;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JsonDocument;
 		result.Should().BeOfType<JsonDocument>();
 		result.Should().NotBeNull();
 		result.RootElement.EnumerateObject().Should().HaveCount(0);
@@ -32,7 +32,7 @@ public class JsonDocumentTests
 	public void JsonDocument_OddNumberOfParameters_ThrowsException()
 	{
 		var expression = new ExtendedExpression("jsonDocument('a', 1, 'b')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*even number of parameters*");
 	}
 
@@ -40,7 +40,7 @@ public class JsonDocumentTests
 	public void JsonDocument_NonStringKey_ThrowsException()
 	{
 		var expression = new ExtendedExpression("jsonDocument(123, 'value')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*requires a string key*");
 	}
 
@@ -48,7 +48,7 @@ public class JsonDocumentTests
 	public void JsonDocument_DuplicateKey_ThrowsException()
 	{
 		var expression = new ExtendedExpression("jsonDocument('a', 1, 'a', 2)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*can only define property a once*");
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/JsonDocumentValidationTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/JsonDocumentValidationTests.cs
@@ -10,7 +10,7 @@ public class JsonDocumentValidationTests
 	{
 		// Test that the basic jsonDocument function works
 		var expression = new ExtendedExpression("jsonDocument('test', 'value')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<JsonDocument>();
 
 		var jsonDoc = result as JsonDocument;
@@ -23,7 +23,7 @@ public class JsonDocumentValidationTests
 	{
 		// Test that the basic jsonArray function works
 		var expression = new ExtendedExpression("jsonArray(1, 2, 3)");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<JsonDocument>();
 
 		var jsonDoc = result as JsonDocument;
@@ -37,7 +37,7 @@ public class JsonDocumentValidationTests
 	{
 		// Test that getProperty works with JsonDocument
 		var expression = new ExtendedExpression("getProperty(jsonDocument('name', 'John'), 'name')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be("John");
 	}
 
@@ -46,7 +46,7 @@ public class JsonDocumentValidationTests
 	{
 		// Test that getProperties works with JsonDocument
 		var expression = new ExtendedExpression("getProperties(jsonDocument('a', 1, 'b', 2))");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(2);
 		result.Should().Contain("a");
@@ -58,7 +58,7 @@ public class JsonDocumentValidationTests
 	{
 		// Test that parse function works with JsonDocument
 		var expression = new ExtendedExpression("parse('JsonDocument', '{\"key\": \"value\"}')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<JsonDocument>();
 
 		var jsonDoc = result as JsonDocument;

--- a/PanoramicData.NCalcExtensions.Test/JsonPathTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/JsonPathTests.cs
@@ -12,7 +12,7 @@ public class JsonPathTests
 		var expression = new ExtendedExpression("getProperty(source, 'name')");
 		var jsonDoc = JsonDocument.Parse("{\"name\": \"bob\", \"numbers\": [1, 2]}");
 		expression.Parameters["source"] = jsonDoc;
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be("bob");
 	}
 
@@ -23,7 +23,7 @@ public class JsonPathTests
 		var expression = new ExtendedExpression("getProperty(source, 'numbers')");
 		var jsonDoc = JsonDocument.Parse("{\"name\": \"bob\", \"numbers\": [1, 2]}");
 		expression.Parameters["source"] = jsonDoc;
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<JsonElement>();
 
 		var jsonElement = (JsonElement)result;
@@ -37,7 +37,7 @@ public class JsonPathTests
 		var expression = new ExtendedExpression("getProperty(source, 'details')");
 		var jsonDoc = JsonDocument.Parse("{\"name\": \"bob\", \"details\": {\"age\": 30, \"city\": \"NYC\"}}");
 		expression.Parameters["source"] = jsonDoc;
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<JsonElement>();
 
 		var jsonElement = (JsonElement)result;
@@ -50,7 +50,7 @@ public class JsonPathTests
 		var expression = new ExtendedExpression("getProperties(source)");
 		var jsonDoc = JsonDocument.Parse("{\"name\": \"bob\", \"numbers\": [1, 2], \"active\": true}");
 		expression.Parameters["source"] = jsonDoc;
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
@@ -65,7 +65,7 @@ public class JsonPathTests
 		var expression = new ExtendedExpression("getProperty(source, 'nonexistent')");
 		var jsonDoc = JsonDocument.Parse("{\"name\": \"bob\"}");
 		expression.Parameters["source"] = jsonDoc;
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeNull();
 	}
 
@@ -75,7 +75,7 @@ public class JsonPathTests
 		var jsonDoc = JsonDocument.Parse("{\"person\": {\"name\": \"alice\", \"age\": 25}}");
 		var expression = new ExtendedExpression("getProperty(personElement, 'name')");
 		expression.Parameters["personElement"] = jsonDoc.RootElement.GetProperty("person");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be("alice");
 	}
 
@@ -85,7 +85,7 @@ public class JsonPathTests
 		var expression = new ExtendedExpression("toString(typeOf(source))");
 		var jsonDoc = JsonDocument.Parse("{\"name\": \"bob\"}");
 		expression.Parameters["source"] = jsonDoc;
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be("JsonDocument");
 	}
 
@@ -95,7 +95,7 @@ public class JsonPathTests
 		var jsonDoc = JsonDocument.Parse("{\"name\": \"bob\"}");
 		var expression = new ExtendedExpression("toString(typeOf(element))");
 		expression.Parameters["element"] = jsonDoc.RootElement;
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be("JsonElement");
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/LastIndexOfTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/LastIndexOfTests.cs
@@ -32,21 +32,21 @@ public class LastIndexOfTests : NCalcTest
 	[InlineData("lastIndexOf('test')")]
 	public void LastIndexOf_InsufficientParameters_ThrowsException(string expression)
 		=> new ExtendedExpression(expression)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>();
 
 	[Fact]
 	public void LastIndexOf_NullFirstParameter_ThrowsException()
 		=> new ExtendedExpression("lastIndexOf(null, 'test')")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>();
 
 	[Fact]
 	public void LastIndexOf_NullSecondParameter_ThrowsException()
 		=> new ExtendedExpression("lastIndexOf('test', null)")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>();
 }

--- a/PanoramicData.NCalcExtensions.Test/LastOrDefaultTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/LastOrDefaultTests.cs
@@ -6,7 +6,7 @@ public class LastOrDefaultTests
 	public void LastOrDefault_MatchingItem_Succeeds()
 	{
 		var expression = new ExtendedExpression("lastOrDefault(list(1, 5, 2, 3, 4, 1), 'n', 'n % 2 == 0')");
-		var result = expression.Evaluate() as int?;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as int?;
 
 		result.Should().Be(4);
 	}
@@ -15,7 +15,7 @@ public class LastOrDefaultTests
 	public void LastOrDefault_NoMatchingStringItem_Succeeds()
 	{
 		var expression = new ExtendedExpression("lastOrDefault(split('', ' '))");
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 
 		result.Should().Be(string.Empty);
 	}
@@ -24,7 +24,7 @@ public class LastOrDefaultTests
 	public void LastOrDefault_MatchingStringItem_Succeeds()
 	{
 		var expression = new ExtendedExpression("lastOrDefault(split('a b c', ' '))");
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 
 		result.Should().Be("c");
 	}
@@ -33,7 +33,7 @@ public class LastOrDefaultTests
 	public void FirstOrDefault_NoMatchingItem_Succeeds()
 	{
 		var expression = new ExtendedExpression("lastOrDefault(list(1, 5, 7, 3), 'n', 'n % 2 == 0')");
-		var result = expression.Evaluate() as int?;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as int?;
 
 		result.Should().BeNull();
 	}

--- a/PanoramicData.NCalcExtensions.Test/LastTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/LastTests.cs
@@ -8,7 +8,7 @@ public class LastTests
 	public void Last_Succeeds()
 	{
 		var expression = new ExtendedExpression("last(list(1, 5, 2, 3, 4, 1), 'n', 'n % 2 == 0')");
-		var result = expression.Evaluate() as int?;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as int?;
 
 		result.Should().Be(4);
 	}
@@ -17,7 +17,7 @@ public class LastTests
 	public void Last_SplittingString_Succeeds()
 	{
 		var expression = new ExtendedExpression("last(split('a b c', ' '))");
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 
 		result.Should().Be("c");
 	}
@@ -28,7 +28,7 @@ public class LastTests
 		var expression = new ExtendedExpression("store('x', list(1, 5, 2, 3, 4, 1)) && last(retrieve('x'), 'n', 'n % 2 == 0') == 4");
 
 		expression
-			.Evaluate()
+			.Evaluate(TestContext.Current.CancellationToken)
 			.Should()
 			.Be(true);
 	}
@@ -39,7 +39,7 @@ public class LastTests
 		var expression = new ExtendedExpression("last(list(1, 5, 7, 3), 'n', 'n % 2 == 0')");
 
 		expression
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>();
 	}
@@ -51,7 +51,7 @@ public class ReverseTests
 	public void Reverse_Succeeds()
 	{
 		var expression = new ExtendedExpression("reverse(list(1, 2, 3, 4, 5, 5))");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 
 		result.Should().BeEquivalentTo(new List<object?> { 5, 5, 4, 3, 2, 1 });
 	}
@@ -62,7 +62,7 @@ public class ReverseTests
 		var expression = new ExtendedExpression("reverse(1)");
 
 		expression
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>();
 	}

--- a/PanoramicData.NCalcExtensions.Test/LengthTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/LengthTests.cs
@@ -6,7 +6,7 @@ public class LengthTests
 	public void Length_OfString_ReturnsExpectedResult()
 	{
 		var expression = new ExtendedExpression($"length('a piece of string')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(17);
 	}
 
@@ -14,7 +14,7 @@ public class LengthTests
 	public void Length_OfList_ReturnsExpectedResult()
 	{
 		var expression = new ExtendedExpression($"length(split('a piece of string', ' '))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(4);
 	}
 
@@ -22,7 +22,7 @@ public class LengthTests
 	public void Length_EmptyString_ReturnsZero()
 	{
 		var expression = new ExtendedExpression("length('')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(0);
 	}
 
@@ -30,7 +30,7 @@ public class LengthTests
 	public void Length_EmptyList_ReturnsZero()
 	{
 		var expression = new ExtendedExpression("length(list())");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(0);
 	}
 
@@ -38,13 +38,13 @@ public class LengthTests
 	public void Length_NullParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("length(null)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>();
 	}
 
 	[Fact]
 	public void Length_NonStringNonListParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("length(123)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>();
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/ListOfTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/ListOfTests.cs
@@ -8,62 +8,62 @@ public class ListOfTests
 	public void List_OfInts_ReturnsExpectedType()
 	{
 		var expression = new ExtendedExpression($"listOf('int', 1, 2, 3)");
-		expression.Evaluate().Should().BeOfType<List<int>>();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeOfType<List<int>>();
 	}
 
 	[Fact]
 	public void List_OfInts_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression($"listOf('int', 1, 2, 3)");
-		expression.Evaluate().Should().BeEquivalentTo(new List<int> { 1, 2, 3 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<int> { 1, 2, 3 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void List_OfLongs_IsForgivingToInts()
 	{
 		var expression = new ExtendedExpression($"listOf('long', 1, 2, 3)");
-		expression.Evaluate().Should().BeEquivalentTo(new List<long> { 1, 2, 3 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<long> { 1, 2, 3 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void List_OfInts_IsForgivingToDoubles()
 	{
 		var expression = new ExtendedExpression($"listOf('int', 1.0, 2.0, 3.1)");
-		expression.Evaluate().Should().BeEquivalentTo(new List<int> { 1, 2, 3 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<int> { 1, 2, 3 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void List_OfDoubles_IsForgivingToInts()
 	{
 		var expression = new ExtendedExpression($"listOf('double', 1, 2, 3)");
-		expression.Evaluate().Should().BeEquivalentTo(new List<double> { 1, 2, 3 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<double> { 1, 2, 3 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void List_OfExpressions_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression($"listOf('int', 2 - 1, 2 + 0, 5 - 2)");
-		expression.Evaluate().Should().BeEquivalentTo(new List<int> { 1, 2, 3 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<int> { 1, 2, 3 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void List_OfStrings_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression($"listOf('string', '1', '2', '3')");
-		expression.Evaluate().Should().BeEquivalentTo(new List<string> { "1", "2", "3" }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<string> { "1", "2", "3" }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void List_WhichIsEmpty_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression($"listOf('string')");
-		expression.Evaluate().Should().BeEquivalentTo(new List<string>(), options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<string>(), options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void List_OfMixedTypes_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression($"listOf('object', null, 1-1, '1')");
-		expression.Evaluate().Should().BeEquivalentTo(new List<object> { null!, 0, "1" }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<object> { null!, 0, "1" }, options => options.WithStrictOrdering());
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/ListTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/ListTests.cs
@@ -8,41 +8,41 @@ public class ListTests
 	public void List_OfInts_ReturnsExpectedType()
 	{
 		var expression = new ExtendedExpression($"list(1, 2, 3)");
-		expression.Evaluate().Should().BeOfType<List<object?>>();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeOfType<List<object?>>();
 	}
 
 	[Fact]
 	public void List_OfInts_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression($"list(1, 2, 3)");
-		expression.Evaluate().Should().BeEquivalentTo(new List<object> { 1, 2, 3 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<object> { 1, 2, 3 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void List_OfExpressions_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression($"list(2 - 1, 2 + 0, 5 - 2)");
-		expression.Evaluate().Should().BeEquivalentTo(new List<object> { 1, 2, 3 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<object> { 1, 2, 3 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void List_OfStrings_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression($"list('1', '2', '3')");
-		expression.Evaluate().Should().BeEquivalentTo(new List<object> { "1", "2", "3" }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<object> { "1", "2", "3" }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void List_WhichIsEmpty_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression($"list()");
-		expression.Evaluate().Should().BeEquivalentTo(new List<object>(), options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<object>(), options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void List_OfMixedTypes_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression($"list(null, 1-1, '1')");
-		expression.Evaluate().Should().BeEquivalentTo(new List<object> { null!, 0, "1" }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<object> { null!, 0, "1" }, options => options.WithStrictOrdering());
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/MaxTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/MaxTests.cs
@@ -19,7 +19,7 @@ public class MaxTests
 	public void Max_OfListOfNullableDoubles_ReturnsExpectedValue(string values, object? expectedOutput)
 	{
 		var expression = new ExtendedExpression($"max(listOf('double?', {values}), 'x', 'x')");
-		expression.Evaluate().Should().BeEquivalentTo(expectedOutput);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(expectedOutput);
 	}
 
 	[Theory]
@@ -32,7 +32,7 @@ public class MaxTests
 	public void Max_OfListNumbers_WithLambda_ReturnsExpectedValue(string values, int expectedOutput)
 	{
 		var expression = new ExtendedExpression($"max(list({values}), 'x', 'x')");
-		expression.Evaluate().Should().BeEquivalentTo(expectedOutput);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(expectedOutput);
 	}
 
 	[Theory]
@@ -45,7 +45,7 @@ public class MaxTests
 	public void Max_OfListNumbers_WithIEnumerable_ReturnsExpectedValue(string values, int expectedOutput)
 	{
 		var expression = new ExtendedExpression($"max(list({values}))");
-		expression.Evaluate().Should().BeEquivalentTo(expectedOutput);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(expectedOutput);
 	}
 
 	[Theory]
@@ -58,7 +58,7 @@ public class MaxTests
 	public void Max_OfStrings_ReturnsExpectedValue(string values, string expectedOutput)
 	{
 		var expression = new ExtendedExpression($"max(list({values}))");
-		expression.Evaluate().Should().BeEquivalentTo(expectedOutput);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(expectedOutput);
 	}
 
 	[Theory]
@@ -74,7 +74,7 @@ public class MaxTests
 
 		var expression = new ExtendedExpression($"max(valuesList)");
 		expression.Parameters["valuesList"] = values.Split(',').Select(x => x == "null" ? null : x).ToList();
-		expression.Evaluate().Should().BeEquivalentTo(expectedOutput);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(expectedOutput);
 	}
 
 	[Fact]
@@ -82,7 +82,7 @@ public class MaxTests
 	public void Max_OfNull_ReturnsExpectedValue()
 	{
 		var expression = new ExtendedExpression($"max(null)");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 
@@ -90,21 +90,21 @@ public class MaxTests
 	public void Max_OfEmptyList_ReturnsNull()
 	{
 		var expression = new ExtendedExpression($"max(list())");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void Max_UsingLambdaForInt_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression($"max(listOf('int', 1, 2, 3), 'x', 'x + 1')");
-		expression.Evaluate().Should().Be(4);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(4);
 	}
 
 	[Fact]
 	public void Max_UsingLambdaForString_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression("max(listOf('string', '1', '2', '3'), 'x', 'x + x')");
-		expression.Evaluate().Should().Be("6");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("6");
 	}
 
 	// Additional comprehensive tests for all numeric types
@@ -113,42 +113,42 @@ public class MaxTests
 	public void Max_ByteType_ReturnsMaxByte()
 	{
 		var expression = new ExtendedExpression("max(listOf('byte', 1, 255, 100))");
-		expression.Evaluate().Should().Be((byte)255);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((byte)255);
 	}
 
 	[Fact]
 	public void Max_SByteType_ReturnsMaxSByte()
 	{
 		var expression = new ExtendedExpression("max(listOf('sbyte', -128, 127, 0))");
-		expression.Evaluate().Should().Be((sbyte)127);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((sbyte)127);
 	}
 
 	[Fact]
 	public void Max_ShortType_ReturnsMaxShort()
 	{
 		var expression = new ExtendedExpression("max(listOf('short', -100, 32767, 100))");
-		expression.Evaluate().Should().Be((short)32767);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((short)32767);
 	}
 
 	[Fact]
 	public void Max_UShortType_ReturnsMaxUShort()
 	{
 		var expression = new ExtendedExpression("max(listOf('ushort', 1, 65535, 100))");
-		expression.Evaluate().Should().Be((ushort)65535);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((ushort)65535);
 	}
 
 	[Fact]
 	public void Max_UIntType_ReturnsMaxUInt()
 	{
 		var expression = new ExtendedExpression("max(listOf('uint', 1, 4294967295, 100))");
-		expression.Evaluate().Should().Be(4294967295u);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(4294967295u);
 	}
 
 	[Fact]
 	public void Max_LongType_ReturnsMaxLong()
 	{
 		var expression = new ExtendedExpression("max(listOf('long', -1000, 9223372036854775807, 1000))");
-		expression.Evaluate().Should().Be(9223372036854775807L);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(9223372036854775807L);
 	}
 
 	[Fact]
@@ -156,14 +156,14 @@ public class MaxTests
 	{
 		// Note: Using values that can be safely represented in double (which NCalc uses for numeric literals)
 		var expression = new ExtendedExpression("max(listOf('ulong', 1, 9999999999999, 100))");
-		expression.Evaluate().Should().Be(9999999999999UL);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(9999999999999UL);
 	}
 
 	[Fact]
 	public void Max_FloatType_ReturnsMaxFloat()
 	{
 		var expression = new ExtendedExpression("max(listOf('float', 1.1, 2.2, 3.3))");
-		var result = (float)expression.Evaluate()!;
+		var result = (float)expression.Evaluate(TestContext.Current.CancellationToken)!;
 		result.Should().BeApproximately(3.3f, 0.01f);
 	}
 
@@ -171,63 +171,63 @@ public class MaxTests
 	public void Max_DecimalType_ReturnsMaxDecimal()
 	{
 		var expression = new ExtendedExpression("max(listOf('decimal', 1.1, 2.2, 3.3))");
-		expression.Evaluate().Should().Be(3.3m);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(3.3m);
 	}
 
 	[Fact]
 	public void Max_WithLambda_EmptyList_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("max(list(), 'x', 'x')");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void Max_NullableInt_WithNulls_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('int?', 1, null, 3, null, 2))");
-		expression.Evaluate().Should().Be(3);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(3);
 	}
 
 	[Fact]
 	public void Max_NullableInt_AllNulls_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("max(listOf('int?', null, null, null))");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void Max_WithLambda_ReturningNull_HandlesCorrectly()
 	{
 		var expression = new ExtendedExpression("max(listOf('int?', 1, 2, 3), 'x', 'if(x == 2, null, x)')");
-		expression.Evaluate().Should().Be(3);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(3);
 	}
 
 	[Fact]
 	public void Max_VeryLargeNumbers_HandlesCorrectly()
 	{
 		var expression = new ExtendedExpression("max(listOf('long', 9223372036854775806, 9223372036854775807))");
-		expression.Evaluate().Should().Be(9223372036854775807L);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(9223372036854775807L);
 	}
 
 	[Fact]
 	public void Max_NegativeNumbers_ReturnsLeastNegative()
 	{
 		var expression = new ExtendedExpression("max(listOf('int', -100, -50, -200))");
-		expression.Evaluate().Should().Be(-50);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(-50);
 	}
 
 	[Fact]
 	public void Max_SingleElement_ReturnsThatElement()
 	{
 		var expression = new ExtendedExpression("max(listOf('int', 42))");
-		expression.Evaluate().Should().Be(42);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(42);
 	}
 
 	[Fact]
 	public void Max_WithLambda_ComplexExpression_Works()
 	{
 		var expression = new ExtendedExpression("max(listOf('int', 1, 2, 3), 'x', 'x * x')");
-		expression.Evaluate().Should().Be(9);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(9);
 	}
 
 	// Lambda form tests for additional numeric types
@@ -236,35 +236,35 @@ public class MaxTests
 	public void Max_WithLambda_UIntType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('uint', 100, 50, 200), 'x', 'x')");
-		expression.Evaluate().Should().Be(200u);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(200u);
 	}
 
 	[Fact]
 	public void Max_WithLambda_NullableUIntType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('uint?', 100, null, 50, 200), 'x', 'x')");
-		expression.Evaluate().Should().Be(200u);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(200u);
 	}
 
 	[Fact]
 	public void Max_WithLambda_ULongType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('ulong', 1000, 500, 2000), 'x', 'x')");
-		expression.Evaluate().Should().Be(2000UL);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(2000UL);
 	}
 
 	[Fact]
 	public void Max_WithLambda_NullableULongType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('ulong?', 1000, null, 500, 2000), 'x', 'x')");
-		expression.Evaluate().Should().Be(2000UL);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(2000UL);
 	}
 
 	[Fact]
 	public void Max_WithLambda_FloatType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('float', 3.3, 1.1, 2.2), 'x', 'x')");
-		var result = (float)expression.Evaluate()!;
+		var result = (float)expression.Evaluate(TestContext.Current.CancellationToken)!;
 		result.Should().BeApproximately(3.3f, 0.01f);
 	}
 
@@ -272,7 +272,7 @@ public class MaxTests
 	public void Max_WithLambda_NullableFloatType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('float?', 3.3, null, 1.1, 2.2), 'x', 'x')");
-		var result = (float)expression.Evaluate()!;
+		var result = (float)expression.Evaluate(TestContext.Current.CancellationToken)!;
 		result.Should().BeApproximately(3.3f, 0.01f);
 	}
 
@@ -280,112 +280,112 @@ public class MaxTests
 	public void Max_WithLambda_DoubleType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('double', 3.3, 1.1, 2.2), 'x', 'x')");
-		expression.Evaluate().Should().Be(3.3);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(3.3);
 	}
 
 	[Fact]
 	public void Max_WithLambda_NullableDoubleType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('double?', 3.3, null, 1.1, 2.2), 'x', 'x')");
-		expression.Evaluate().Should().Be(3.3);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(3.3);
 	}
 
 	[Fact]
 	public void Max_WithLambda_DecimalType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('decimal', 3.3, 1.1, 2.2), 'x', 'x')");
-		expression.Evaluate().Should().Be(3.3m);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(3.3m);
 	}
 
 	[Fact]
 	public void Max_WithLambda_NullableDecimalType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('decimal?', 3.3, null, 1.1, 2.2), 'x', 'x')");
-		expression.Evaluate().Should().Be(3.3m);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(3.3m);
 	}
 
 	[Fact]
 	public void Max_WithLambda_SByteType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('sbyte', 10, -5, 3), 'x', 'x')");
-		expression.Evaluate().Should().Be(10);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(10);
 	}
 
 	[Fact]
 	public void Max_WithLambda_NullableSByteType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('sbyte?', 10, null, -5, 3), 'x', 'x')");
-		expression.Evaluate().Should().Be(10);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(10);
 	}
 
 	[Fact]
 	public void Max_WithLambda_ByteType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('byte', 100, 50, 200), 'x', 'x')");
-		expression.Evaluate().Should().Be(200);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(200);
 	}
 
 	[Fact]
 	public void Max_WithLambda_NullableByteType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('byte?', 100, null, 50, 200), 'x', 'x')");
-		expression.Evaluate().Should().Be(200);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(200);
 	}
 
 	[Fact]
 	public void Max_WithLambda_ShortType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('short', 1000, 500, 2000), 'x', 'x')");
-		expression.Evaluate().Should().Be(2000);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(2000);
 	}
 
 	[Fact]
 	public void Max_WithLambda_NullableShortType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('short?', 1000, null, 500, 2000), 'x', 'x')");
-		expression.Evaluate().Should().Be(2000);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(2000);
 	}
 
 	[Fact]
 	public void Max_WithLambda_UShortType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('ushort', 1000, 500, 2000), 'x', 'x')");
-		expression.Evaluate().Should().Be(2000);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(2000);
 	}
 
 	[Fact]
 	public void Max_WithLambda_NullableUShortType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('ushort?', 1000, null, 500, 2000), 'x', 'x')");
-		expression.Evaluate().Should().Be(2000);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(2000);
 	}
 
 	[Fact]
 	public void Max_WithLambda_LongType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('long', 1000, 500, 2000), 'x', 'x')");
-		expression.Evaluate().Should().Be(2000L);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(2000L);
 	}
 
 	[Fact]
 	public void Max_WithLambda_NullableLongType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('long?', 1000, null, 500, 2000), 'x', 'x')");
-		expression.Evaluate().Should().Be(2000L);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(2000L);
 	}
 
 	[Fact]
 	public void Max_WithLambda_StringType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('string', 'abc', 'xyz', 'def'), 'x', 'x')");
-		expression.Evaluate().Should().Be("xyz");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("xyz");
 	}
 
 	[Fact]
 	public void Max_WithLambda_NullableStringType_ReturnsMax()
 	{
 		var expression = new ExtendedExpression("max(listOf('string?', 'abc', null, 'xyz', 'def'), 'x', 'x')");
-		expression.Evaluate().Should().Be("xyz");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("xyz");
 	}
 
 	// Error path tests
@@ -394,7 +394,7 @@ public class MaxTests
 	public void Max_WithInvalidFirstParameter_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression("max('not a list')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*must be an IEnumerable*");
 	}
@@ -403,7 +403,7 @@ public class MaxTests
 	public void Max_WithLambda_InvalidSecondParameter_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression("max(list(1, 2, 3), 123, 'x')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*Second*parameter must be a string*");
 	}
@@ -412,7 +412,7 @@ public class MaxTests
 	public void Max_WithLambda_InvalidThirdParameter_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression("max(list(1, 2, 3), 'x', 456)");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*Third*parameter must be a string*");
 	}
@@ -423,7 +423,7 @@ public class MaxTests
 	{
 		var expression = new ExtendedExpression("max(unsupportedList)");
 		expression.Parameters["unsupportedList"] = new List<object?> { new System.DateTime(2024, 1, 1), new System.DateTime(2024, 1, 2) };
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*Found unsupported type*");
 	}
@@ -435,7 +435,7 @@ public class MaxTests
 		var expression = new ExtendedExpression("max(jValueList)");
 		// Create a JValue with an unsupported type (e.g., Boolean or Date)
 		expression.Parameters["jValueList"] = new List<object?> { new JValue(true), new JValue(false) };
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*Found unsupported JToken type*");
 	}
@@ -446,7 +446,7 @@ public class MaxTests
 	{
 		var expression = new ExtendedExpression("max(dateList)");
 		expression.Parameters["dateList"] = new List<DateTime> { DateTime.Now, DateTime.Now.AddDays(1) };
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*must be an IEnumerable of a numeric or string type*");
 	}
@@ -457,7 +457,7 @@ public class MaxTests
 	{
 		var expression = new ExtendedExpression("max(dateList, 'x', 'x')");
 		expression.Parameters["dateList"] = new List<DateTime> { DateTime.Now, DateTime.Now.AddDays(1) };
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*must be an IEnumerable of a string or numeric type when processing as a lambda*");
 	}

--- a/PanoramicData.NCalcExtensions.Test/MaxValueTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/MaxValueTests.cs
@@ -16,35 +16,35 @@ public class MaxValueTests
 	public void MaxValue_ReturnsExpectedValue(string type, object expectedOutput)
 	{
 		var expression = new ExtendedExpression($"maxValue('{type}')");
-		expression.Evaluate().Should().BeEquivalentTo(expectedOutput);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(expectedOutput);
 	}
 
 	[Fact]
 	public void MaxValue_ForDecimal_ReturnsExpectedValue()
 	{
 		var expression = new ExtendedExpression($"maxValue('decimal')");
-		expression.Evaluate().Should().BeEquivalentTo(decimal.MaxValue);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(decimal.MaxValue);
 	}
 
 	[Fact]
 	public void MaxValue_ForDateTime_ReturnsExpectedValue()
 	{
 		var expression = new ExtendedExpression($"maxValue('DateTime')");
-		expression.Evaluate().Should().BeEquivalentTo(DateTime.MaxValue);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(DateTime.MaxValue);
 	}
 
 	[Fact]
 	public void MaxValue_ForDateTimeOffset_ReturnsExpectedValue()
 	{
 		var expression = new ExtendedExpression($"maxValue('DateTimeOffset')");
-		expression.Evaluate().Should().BeEquivalentTo(DateTimeOffset.MaxValue);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(DateTimeOffset.MaxValue);
 	}
 
 	[Fact]
 	public void MaxValue_ForUnsupportedType_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression($"maxValue('unsupportedType')");
-		expression.Invoking(x => x.Evaluate()).Should().Throw<FormatException>();
+		expression.Invoking(x => x.Evaluate(TestContext.Current.CancellationToken)).Should().Throw<FormatException>();
 	}
 
 	// Error path tests
@@ -53,7 +53,7 @@ public class MaxValueTests
 	public void MaxValue_NoParameters_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression("maxValue()");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<Exception>();
 	}
 
@@ -61,7 +61,7 @@ public class MaxValueTests
 	public void MaxValue_TwoParameters_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression("maxValue('int', 'extra')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*takes exactly one string parameter*");
 	}
@@ -70,7 +70,7 @@ public class MaxValueTests
 	public void MaxValue_NullParameter_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression("maxValue(null)");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*takes exactly one string parameter*");
 	}
@@ -79,7 +79,7 @@ public class MaxValueTests
 	public void MaxValue_NumericParameter_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression("maxValue(123)");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*takes exactly one string parameter*");
 	}
@@ -88,7 +88,7 @@ public class MaxValueTests
 	public void MaxValue_EmptyString_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression("maxValue('')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*takes exactly one string parameter*");
 	}
@@ -98,7 +98,7 @@ public class MaxValueTests
 	{
 		// Type names are case-sensitive
 		var expression = new ExtendedExpression("maxValue('INT')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*takes exactly one string parameter*");
 	}
@@ -107,7 +107,7 @@ public class MaxValueTests
 	public void MaxValue_SystemNamespace_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression("maxValue('System.Int32')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*takes exactly one string parameter*");
 	}
@@ -118,14 +118,14 @@ public class MaxValueTests
 	public void MaxValue_UsedInComparison_Works()
 	{
 		var expression = new ExtendedExpression("1000 < maxValue('int')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void MaxValue_UsedInArithmetic_Works()
 	{
 		var expression = new ExtendedExpression("maxValue('byte') + 1");
-		expression.Evaluate().Should().Be(256);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(256);
 	}
 
 	[Fact]
@@ -133,14 +133,14 @@ public class MaxValueTests
 	{
 		var expression = new ExtendedExpression("value == maxValue('int')");
 		expression.Parameters["value"] = int.MaxValue;
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void MaxValue_DifferentTypesHaveDifferentValues()
 	{
-		var byteMax = new ExtendedExpression("maxValue('byte')").Evaluate();
-		var ushortMax = new ExtendedExpression("maxValue('ushort')").Evaluate();
+		var byteMax = new ExtendedExpression("maxValue('byte')").Evaluate(TestContext.Current.CancellationToken);
+		var ushortMax = new ExtendedExpression("maxValue('ushort')").Evaluate(TestContext.Current.CancellationToken);
 		((byte)byteMax! < (ushort)ushortMax!).Should().BeTrue();
 	}
 
@@ -148,7 +148,7 @@ public class MaxValueTests
 	public void MaxValue_DateTime_IsGreaterThanNow()
 	{
 		var expression = new ExtendedExpression("maxValue('DateTime') > now()");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	// Specific value validation tests
@@ -157,27 +157,27 @@ public class MaxValueTests
 	public void MaxValue_SByte_Equals127()
 	{
 		var expression = new ExtendedExpression("maxValue('sbyte')");
-		expression.Evaluate().Should().Be((sbyte)127);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((sbyte)127);
 	}
 
 	[Fact]
 	public void MaxValue_Byte_Equals255()
 	{
 		var expression = new ExtendedExpression("maxValue('byte')");
-		expression.Evaluate().Should().Be((byte)255);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((byte)255);
 	}
 
 	[Fact]
 	public void MaxValue_UShort_Equals65535()
 	{
 		var expression = new ExtendedExpression("maxValue('ushort')");
-		expression.Evaluate().Should().Be((ushort)65535);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((ushort)65535);
 	}
 
 	[Fact]
 	public void MaxValue_Int_Equals2147483647()
 	{
 		var expression = new ExtendedExpression("maxValue('int')");
-		expression.Evaluate().Should().Be(2147483647);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(2147483647);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/MinTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/MinTests.cs
@@ -19,7 +19,7 @@ public class MinTests
 	public void Min_OfNumbers_ReturnsExpectedValue(string values, object? expectedOutput)
 	{
 		var expression = new ExtendedExpression($"min(listOf('double?', {values}), 'x', 'x')");
-		expression.Evaluate().Should().BeEquivalentTo(expectedOutput);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(expectedOutput);
 	}
 
 	[Theory]
@@ -32,7 +32,7 @@ public class MinTests
 	public void Min_OfListNumbers_WithLambda_ReturnsExpectedValue(string values, int expectedOutput)
 	{
 		var expression = new ExtendedExpression($"min(list({values}), 'x', 'x')");
-		expression.Evaluate().Should().BeEquivalentTo(expectedOutput);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(expectedOutput);
 	}
 
 	[Theory]
@@ -45,7 +45,7 @@ public class MinTests
 	public void Min_OfListNumbers_WithIEnumerable_ReturnsExpectedValue(string values, int expectedOutput)
 	{
 		var expression = new ExtendedExpression($"min(list({values}))");
-		expression.Evaluate().Should().BeEquivalentTo(expectedOutput);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(expectedOutput);
 	}
 
 	[Theory]
@@ -58,7 +58,7 @@ public class MinTests
 	public void Min_OfStrings_ReturnsExpectedValue(string values, string expectedOutput)
 	{
 		var expression = new ExtendedExpression($"min(list({values}))");
-		expression.Evaluate().Should().BeEquivalentTo(expectedOutput);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(expectedOutput);
 	}
 
 	[Theory]
@@ -74,7 +74,7 @@ public class MinTests
 
 		var expression = new ExtendedExpression($"min(valuesList)");
 		expression.Parameters["valuesList"] = values.Split(',').Select(x => x == "null" ? null : x).ToList();
-		expression.Evaluate().Should().BeEquivalentTo(expectedOutput);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(expectedOutput);
 	}
 
 	[Fact]
@@ -82,28 +82,28 @@ public class MinTests
 	public void Min_OfNull_ReturnsExpectedValue()
 	{
 		var expression = new ExtendedExpression($"min(null)");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void Min_OfEmptyList_ReturnsNull()
 	{
 		var expression = new ExtendedExpression($"min(list())");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void Min_UsingLambdaForInt_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression($"min(listOf('int', 1, 2, 3), 'x', 'x + 1')");
-		expression.Evaluate().Should().Be(2);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(2);
 	}
 
 	[Fact]
 	public void Min_UsingLambdaForString_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression("min(listOf('string', '1', '2', '3'), 'x', 'x + x')");
-		expression.Evaluate().Should().Be("2");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("2");
 	}
 
 	// Additional comprehensive tests for all numeric types
@@ -112,42 +112,42 @@ public class MinTests
 	public void Min_ByteType_ReturnsMinByte()
 	{
 		var expression = new ExtendedExpression("min(listOf('byte', 255, 1, 100))");
-		expression.Evaluate().Should().Be((byte)1);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((byte)1);
 	}
 
 	[Fact]
 	public void Min_SByteType_ReturnsMinSByte()
 	{
 		var expression = new ExtendedExpression("min(listOf('sbyte', 127, -128, 0))");
-		expression.Evaluate().Should().Be((sbyte)-128);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((sbyte)-128);
 	}
 
 	[Fact]
 	public void Min_ShortType_ReturnsMinShort()
 	{
 		var expression = new ExtendedExpression("min(listOf('short', 32767, -100, 100))");
-		expression.Evaluate().Should().Be((short)-100);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((short)-100);
 	}
 
 	[Fact]
 	public void Min_UShortType_ReturnsMinUShort()
 	{
 		var expression = new ExtendedExpression("min(listOf('ushort', 65535, 1, 100))");
-		expression.Evaluate().Should().Be((ushort)1);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((ushort)1);
 	}
 
 	[Fact]
 	public void Min_UIntType_ReturnsMinUInt()
 	{
 		var expression = new ExtendedExpression("min(listOf('uint', 4294967295, 1, 100))");
-		expression.Evaluate().Should().Be(1u);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(1u);
 	}
 
 	[Fact]
 	public void Min_LongType_ReturnsMinLong()
 	{
 		var expression = new ExtendedExpression("min(listOf('long', 9223372036854775807, -1000, 1000))");
-		expression.Evaluate().Should().Be(-1000L);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(-1000L);
 	}
 
 	[Fact]
@@ -155,14 +155,14 @@ public class MinTests
 	{
 		// Note: Using values that can be safely represented in double (which NCalc uses for numeric literals)
 		var expression = new ExtendedExpression("min(listOf('ulong', 100, 1, 50))");
-		expression.Evaluate().Should().Be(1UL);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(1UL);
 	}
 
 	[Fact]
 	public void Min_FloatType_ReturnsMinFloat()
 	{
 		var expression = new ExtendedExpression("min(listOf('float', 3.3, 1.1, 2.2))");
-		var result = (float)expression.Evaluate()!;
+		var result = (float)expression.Evaluate(TestContext.Current.CancellationToken)!;
 		result.Should().BeApproximately(1.1f, 0.01f);
 	}
 
@@ -170,63 +170,63 @@ public class MinTests
 	public void Min_DecimalType_ReturnsMinDecimal()
 	{
 		var expression = new ExtendedExpression("min(listOf('decimal', 3.3, 1.1, 2.2))");
-		expression.Evaluate().Should().Be(1.1m);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(1.1m);
 	}
 
 	[Fact]
 	public void Min_WithLambda_EmptyList_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("min(list(), 'x', 'x')");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void Min_NullableInt_WithNulls_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('int?', 3, null, 1, null, 2))");
-		expression.Evaluate().Should().Be(1);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(1);
 	}
 
 	[Fact]
 	public void Min_NullableInt_AllNulls_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("min(listOf('int?', null, null, null))");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void Min_WithLambda_ReturningNull_HandlesCorrectly()
 	{
 		var expression = new ExtendedExpression("min(listOf('int?', 1, 2, 3), 'x', 'if(x == 2, null, x)')");
-		expression.Evaluate().Should().Be(1);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(1);
 	}
 
 	[Fact]
 	public void Min_VeryLargeNumbers_HandlesCorrectly()
 	{
 		var expression = new ExtendedExpression("min(listOf('long', 9223372036854775806, 9223372036854775807))");
-		expression.Evaluate().Should().Be(9223372036854775806L);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(9223372036854775806L);
 	}
 
 	[Fact]
 	public void Min_NegativeNumbers_ReturnsMostNegative()
 	{
 		var expression = new ExtendedExpression("min(listOf('int', -100, -50, -200))");
-		expression.Evaluate().Should().Be(-200);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(-200);
 	}
 
 	[Fact]
 	public void Min_SingleElement_ReturnsThatElement()
 	{
 		var expression = new ExtendedExpression("min(listOf('int', 42))");
-		expression.Evaluate().Should().Be(42);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(42);
 	}
 
 	[Fact]
 	public void Min_WithLambda_ComplexExpression_Works()
 	{
 		var expression = new ExtendedExpression("min(listOf('int', 1, 2, 3), 'x', 'x * x')");
-		expression.Evaluate().Should().Be(1);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(1);
 	}
 
 	// Lambda form tests for additional numeric types
@@ -235,35 +235,35 @@ public class MinTests
 	public void Min_WithLambda_UIntType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('uint', 100, 50, 200), 'x', 'x')");
-		expression.Evaluate().Should().Be(50u);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(50u);
 	}
 
 	[Fact]
 	public void Min_WithLambda_NullableUIntType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('uint?', 100, null, 50, 200), 'x', 'x')");
-		expression.Evaluate().Should().Be(50u);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(50u);
 	}
 
 	[Fact]
 	public void Min_WithLambda_ULongType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('ulong', 1000, 500, 2000), 'x', 'x')");
-		expression.Evaluate().Should().Be(500UL);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(500UL);
 	}
 
 	[Fact]
 	public void Min_WithLambda_NullableULongType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('ulong?', 1000, null, 500, 2000), 'x', 'x')");
-		expression.Evaluate().Should().Be(500UL);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(500UL);
 	}
 
 	[Fact]
 	public void Min_WithLambda_FloatType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('float', 3.3, 1.1, 2.2), 'x', 'x')");
-		var result = (float)expression.Evaluate()!;
+		var result = (float)expression.Evaluate(TestContext.Current.CancellationToken)!;
 		result.Should().BeApproximately(1.1f, 0.01f);
 	}
 
@@ -271,7 +271,7 @@ public class MinTests
 	public void Min_WithLambda_NullableFloatType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('float?', 3.3, null, 1.1, 2.2), 'x', 'x')");
-		var result = (float)expression.Evaluate()!;
+		var result = (float)expression.Evaluate(TestContext.Current.CancellationToken)!;
 		result.Should().BeApproximately(1.1f, 0.01f);
 	}
 
@@ -279,112 +279,112 @@ public class MinTests
 	public void Min_WithLambda_DoubleType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('double', 3.3, 1.1, 2.2), 'x', 'x')");
-		expression.Evaluate().Should().Be(1.1);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(1.1);
 	}
 
 	[Fact]
 	public void Min_WithLambda_NullableDoubleType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('double?', 3.3, null, 1.1, 2.2), 'x', 'x')");
-		expression.Evaluate().Should().Be(1.1);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(1.1);
 	}
 
 	[Fact]
 	public void Min_WithLambda_DecimalType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('decimal', 3.3, 1.1, 2.2), 'x', 'x')");
-		expression.Evaluate().Should().Be(1.1m);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(1.1m);
 	}
 
 	[Fact]
 	public void Min_WithLambda_NullableDecimalType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('decimal?', 3.3, null, 1.1, 2.2), 'x', 'x')");
-		expression.Evaluate().Should().Be(1.1m);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(1.1m);
 	}
 
 	[Fact]
 	public void Min_WithLambda_SByteType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('sbyte', 10, -5, 3), 'x', 'x')");
-		expression.Evaluate().Should().Be((sbyte)-5);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((sbyte)-5);
 	}
 
 	[Fact]
 	public void Min_WithLambda_NullableSByteType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('sbyte?', 10, null, -5, 3), 'x', 'x')");
-		expression.Evaluate().Should().Be((sbyte)-5);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((sbyte)-5);
 	}
 
 	[Fact]
 	public void Min_WithLambda_ByteType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('byte', 100, 50, 200), 'x', 'x')");
-		expression.Evaluate().Should().Be((byte)50);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((byte)50);
 	}
 
 	[Fact]
 	public void Min_WithLambda_NullableByteType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('byte?', 100, null, 50, 200), 'x', 'x')");
-		expression.Evaluate().Should().Be((byte)50);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((byte)50);
 	}
 
 	[Fact]
 	public void Min_WithLambda_ShortType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('short', 1000, 500, 2000), 'x', 'x')");
-		expression.Evaluate().Should().Be((short)500);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((short)500);
 	}
 
 	[Fact]
 	public void Min_WithLambda_NullableShortType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('short?', 1000, null, 500, 2000), 'x', 'x')");
-		expression.Evaluate().Should().Be((short)500);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((short)500);
 	}
 
 	[Fact]
 	public void Min_WithLambda_UShortType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('ushort', 1000, 500, 2000), 'x', 'x')");
-		expression.Evaluate().Should().Be((ushort)500);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((ushort)500);
 	}
 
 	[Fact]
 	public void Min_WithLambda_NullableUShortType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('ushort?', 1000, null, 500, 2000), 'x', 'x')");
-		expression.Evaluate().Should().Be((ushort)500);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((ushort)500);
 	}
 
 	[Fact]
 	public void Min_WithLambda_LongType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('long', 1000, 500, 2000), 'x', 'x')");
-		expression.Evaluate().Should().Be(500L);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(500L);
 	}
 
 	[Fact]
 	public void Min_WithLambda_NullableLongType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('long?', 1000, null, 500, 2000), 'x', 'x')");
-		expression.Evaluate().Should().Be(500L);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(500L);
 	}
 
 	[Fact]
 	public void Min_WithLambda_StringType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('string', 'abc', 'xyz', 'def'), 'x', 'x')");
-		expression.Evaluate().Should().Be("abc");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("abc");
 	}
 
 	[Fact]
 	public void Min_WithLambda_NullableStringType_ReturnsMin()
 	{
 		var expression = new ExtendedExpression("min(listOf('string?', 'abc', null, 'xyz', 'def'), 'x', 'x')");
-		expression.Evaluate().Should().Be("abc");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("abc");
 	}
 
 	// Error path tests
@@ -393,7 +393,7 @@ public class MinTests
 	public void Min_WithInvalidFirstParameter_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression("min('not a list')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*must be an IEnumerable*");
 	}
@@ -402,7 +402,7 @@ public class MinTests
 	public void Min_WithLambda_InvalidSecondParameter_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression("min(list(1, 2, 3), 123, 'x')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*Second*parameter must be a string*");
 	}
@@ -411,7 +411,7 @@ public class MinTests
 	public void Min_WithLambda_InvalidThirdParameter_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression("min(list(1, 2, 3), 'x', 456)");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*Third*parameter must be a string*");
 	}
@@ -422,7 +422,7 @@ public class MinTests
 	{
 		var expression = new ExtendedExpression("min(unsupportedList)");
 		expression.Parameters["unsupportedList"] = new List<object?> { new System.DateTime(2024, 1, 1), new System.DateTime(2024, 1, 2) };
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*Found unsupported type*");
 	}
@@ -434,7 +434,7 @@ public class MinTests
 		var expression = new ExtendedExpression("min(jValueList)");
 		// Create a JValue with an unsupported type (e.g., Boolean or Date)
 		expression.Parameters["jValueList"] = new List<object?> { new JValue(true), new JValue(false) };
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*Found unsupported JToken type*");
 	}
@@ -445,7 +445,7 @@ public class MinTests
 	{
 		var expression = new ExtendedExpression("min(dateList)");
 		expression.Parameters["dateList"] = new List<DateTime> { DateTime.Now, DateTime.Now.AddDays(1) };
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*must be an IEnumerable of a numeric or string type*");
 	}
@@ -456,7 +456,7 @@ public class MinTests
 	{
 		var expression = new ExtendedExpression("min(dateList, 'x', 'x')");
 		expression.Parameters["dateList"] = new List<DateTime> { DateTime.Now, DateTime.Now.AddDays(1) };
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*must be an IEnumerable of a string or numeric type when processing as a lambda*");
 	}

--- a/PanoramicData.NCalcExtensions.Test/MinValueTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/MinValueTests.cs
@@ -16,35 +16,35 @@ public class MinValueTests
 	public void MinValue_ReturnsExpectedValue(string type, object expectedOutput)
 	{
 		var expression = new ExtendedExpression($"minValue('{type}')");
-		expression.Evaluate().Should().BeEquivalentTo(expectedOutput);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(expectedOutput);
 	}
 
 	[Fact]
 	public void MinValue_ForDecimal_ReturnsExpectedValue()
 	{
 		var expression = new ExtendedExpression($"minValue('decimal')");
-		expression.Evaluate().Should().BeEquivalentTo(decimal.MinValue);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(decimal.MinValue);
 	}
 
 	[Fact]
 	public void MinValue_ForDateTime_ReturnsExpectedValue()
 	{
 		var expression = new ExtendedExpression($"minValue('DateTime')");
-		expression.Evaluate().Should().BeEquivalentTo(DateTime.MinValue);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(DateTime.MinValue);
 	}
 
 	[Fact]
 	public void MinValue_ForDateTimeOffset_ReturnsExpectedValue()
 	{
 		var expression = new ExtendedExpression($"minValue('DateTimeOffset')");
-		expression.Evaluate().Should().BeEquivalentTo(DateTimeOffset.MinValue);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(DateTimeOffset.MinValue);
 	}
 
 	[Fact]
 	public void MinValue_ForUnsupportedType_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression($"minValue('unsupportedType')");
-		expression.Invoking(x => x.Evaluate()).Should().Throw<FormatException>();
+		expression.Invoking(x => x.Evaluate(TestContext.Current.CancellationToken)).Should().Throw<FormatException>();
 	}
 
 	// Error path tests
@@ -53,7 +53,7 @@ public class MinValueTests
 	public void MinValue_NoParameters_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression("minValue()");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<Exception>();
 	}
 
@@ -61,7 +61,7 @@ public class MinValueTests
 	public void MinValue_TwoParameters_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression("minValue('int', 'extra')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*takes exactly one string parameter*");
 	}
@@ -70,7 +70,7 @@ public class MinValueTests
 	public void MinValue_NullParameter_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression("minValue(null)");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*takes exactly one string parameter*");
 	}
@@ -79,7 +79,7 @@ public class MinValueTests
 	public void MinValue_NumericParameter_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression("minValue(123)");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*takes exactly one string parameter*");
 	}
@@ -88,7 +88,7 @@ public class MinValueTests
 	public void MinValue_EmptyString_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression("minValue('')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*takes exactly one string parameter*");
 	}
@@ -98,7 +98,7 @@ public class MinValueTests
 	{
 		// Type names are case-sensitive
 		var expression = new ExtendedExpression("minValue('INT')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*takes exactly one string parameter*");
 	}
@@ -107,7 +107,7 @@ public class MinValueTests
 	public void MinValue_SystemNamespace_ThrowsFormatException()
 	{
 		var expression = new ExtendedExpression("minValue('System.Int32')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*takes exactly one string parameter*");
 	}
@@ -118,14 +118,14 @@ public class MinValueTests
 	public void MinValue_UsedInComparison_Works()
 	{
 		var expression = new ExtendedExpression("-1000 > minValue('int')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void MinValue_UsedInArithmetic_Works()
 	{
 		var expression = new ExtendedExpression("minValue('byte') - 1");
-		expression.Evaluate().Should().Be(-1);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(-1);
 	}
 
 	[Fact]
@@ -133,14 +133,14 @@ public class MinValueTests
 	{
 		var expression = new ExtendedExpression("value == minValue('int')");
 		expression.Parameters["value"] = int.MinValue;
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void MinValue_DifferentTypesHaveDifferentValues()
 	{
-		var sbyteMin = new ExtendedExpression("minValue('sbyte')").Evaluate();
-		var byteMin = new ExtendedExpression("minValue('byte')").Evaluate();
+		var sbyteMin = new ExtendedExpression("minValue('sbyte')").Evaluate(TestContext.Current.CancellationToken);
+		var byteMin = new ExtendedExpression("minValue('byte')").Evaluate(TestContext.Current.CancellationToken);
 		((sbyte)sbyteMin! < (byte)byteMin!).Should().BeTrue();
 	}
 
@@ -148,7 +148,7 @@ public class MinValueTests
 	public void MinValue_DateTime_IsLessThanNow()
 	{
 		var expression = new ExtendedExpression("minValue('DateTime') < now()");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	// Specific value validation tests
@@ -157,27 +157,27 @@ public class MinValueTests
 	public void MinValue_SByte_EqualsMinus128()
 	{
 		var expression = new ExtendedExpression("minValue('sbyte')");
-		expression.Evaluate().Should().Be((sbyte)-128);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((sbyte)-128);
 	}
 
 	[Fact]
 	public void MinValue_Byte_Equals0()
 	{
 		var expression = new ExtendedExpression("minValue('byte')");
-		expression.Evaluate().Should().Be((byte)0);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be((byte)0);
 	}
 
 	[Fact]
 	public void MinValue_UInt_Equals0()
 	{
 		var expression = new ExtendedExpression("minValue('uint')");
-		expression.Evaluate().Should().Be(0u);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(0u);
 	}
 
 	[Fact]
 	public void MinValue_Int_EqualsMinus2147483648()
 	{
 		var expression = new ExtendedExpression("minValue('int')");
-		expression.Evaluate().Should().Be(-2147483648);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(-2147483648);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/MultiLineTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/MultiLineTests.cs
@@ -28,7 +28,7 @@ if(
 """)]
 	public void All_LessThanFive_Succeeds(string multiLineExpression)
 		=> new ExtendedExpression(multiLineExpression)
-		.Evaluate()
+		.Evaluate(TestContext.Current.CancellationToken)
 		.Should()
 		.Be(true);
 }

--- a/PanoramicData.NCalcExtensions.Test/NCalcTest.cs
+++ b/PanoramicData.NCalcExtensions.Test/NCalcTest.cs
@@ -5,6 +5,6 @@ public abstract class NCalcTest
 	protected static object? Test(string expressionText)
 	{
 		var expression = new ExtendedExpression(expressionText);
-		return expression.Evaluate();
+		return expression.Evaluate(TestContext.Current.CancellationToken);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/NowTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/NowTests.cs
@@ -67,21 +67,21 @@ public class NowTests : NCalcTest
 	[Fact]
 	public void Now_InvalidTimeZone_ThrowsException()
 		=> new ExtendedExpression("now('Invalid/Timezone')")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>();
 
 	[Fact]
 	public void Now_EmptyStringTimeZone_ThrowsException()
 		=> new ExtendedExpression("now('')")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>();
 
 	[Fact]
 	public void Now_NonStringParameter_ThrowsException()
 		=> new ExtendedExpression("now(123)")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*first argument should be a string*");

--- a/PanoramicData.NCalcExtensions.Test/NullCheckingJsonElementTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/NullCheckingJsonElementTests.cs
@@ -10,7 +10,7 @@ public class NullCheckingJsonElementTests
 		var jsonDoc = JsonDocument.Parse("{\"value\": null}");
 		var expression = new ExtendedExpression("isNullOrEmpty(value)");
 		expression.Parameters["value"] = jsonDoc.RootElement.GetProperty("value");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -20,7 +20,7 @@ public class NullCheckingJsonElementTests
 		var jsonDoc = JsonDocument.Parse("{\"value\": \"\"}");
 		var expression = new ExtendedExpression("isNullOrEmpty(value)");
 		expression.Parameters["value"] = jsonDoc.RootElement.GetProperty("value");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -30,7 +30,7 @@ public class NullCheckingJsonElementTests
 		var jsonDoc = JsonDocument.Parse("{\"value\": \"test\"}");
 		var expression = new ExtendedExpression("isNullOrEmpty(value)");
 		expression.Parameters["value"] = jsonDoc.RootElement.GetProperty("value");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(false);
 	}
 
@@ -40,7 +40,7 @@ public class NullCheckingJsonElementTests
 		var jsonDoc = JsonDocument.Parse("{\"value\": null}");
 		var expression = new ExtendedExpression("isNullOrWhiteSpace(value)");
 		expression.Parameters["value"] = jsonDoc.RootElement.GetProperty("value");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -50,7 +50,7 @@ public class NullCheckingJsonElementTests
 		var jsonDoc = JsonDocument.Parse("{\"value\": \"   \"}");
 		var expression = new ExtendedExpression("isNullOrWhiteSpace(value)");
 		expression.Parameters["value"] = jsonDoc.RootElement.GetProperty("value");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -60,7 +60,7 @@ public class NullCheckingJsonElementTests
 		var jsonDoc = JsonDocument.Parse("{\"value\": \"test\"}");
 		var expression = new ExtendedExpression("isNullOrWhiteSpace(value)");
 		expression.Parameters["value"] = jsonDoc.RootElement.GetProperty("value");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(false);
 	}
 
@@ -70,7 +70,7 @@ public class NullCheckingJsonElementTests
 		var jsonDoc = JsonDocument.Parse("{\"value\": null}");
 		var expression = new ExtendedExpression("isNull(value)");
 		expression.Parameters["value"] = jsonDoc.RootElement.GetProperty("value");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -80,7 +80,7 @@ public class NullCheckingJsonElementTests
 		var jsonDoc = JsonDocument.Parse("{\"value\": \"test\"}");
 		var expression = new ExtendedExpression("isNull(value)");
 		expression.Parameters["value"] = jsonDoc.RootElement.GetProperty("value");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(false);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/NullCoalesceTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/NullCoalesceTests.cs
@@ -15,7 +15,7 @@ public class NullCoalesceTests
 	public void Parse_GoodValues_Succeeds(string parameters, object? expectedValue)
 	{
 		var expression = new ExtendedExpression($"nullCoalesce({parameters})");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(expectedValue);
 	}
 
@@ -32,7 +32,7 @@ public class NullCoalesceTests
 		expression.Parameters.Add("a", a);
 		expression.Parameters.Add("b", b);
 		expression.Parameters.Add("c", c);
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(expectedValue);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/NullOperatorTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/NullOperatorTests.cs
@@ -10,5 +10,5 @@ public class NullOperatorTests : NCalcTest
 	[InlineData("null / 1")]
 	[InlineData("null % 1")]
 	public void NullOutputTest_Succeeds(string expressionThatShouldResultInNull)
-		=> new ExtendedExpression(expressionThatShouldResultInNull).Evaluate().Should().BeNull();
+		=> new ExtendedExpression(expressionThatShouldResultInNull).Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 }

--- a/PanoramicData.NCalcExtensions.Test/OrderByTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/OrderByTests.cs
@@ -9,7 +9,7 @@ public class OrderByTests : NCalcTest
 	[InlineData("-n", new[] { 3, 2, 1 })]
 	public void OrderBy_SingleTerm_Succeeds(string expression, int[] expectedOrder)
 		=> new ExtendedExpression($"orderBy(list(2, 1, 3), 'n', '{expression}')")
-		.Evaluate()
+		.Evaluate(TestContext.Current.CancellationToken)
 		.Should()
 		.BeEquivalentTo(expectedOrder, options => options.WithStrictOrdering());
 
@@ -18,7 +18,7 @@ public class OrderByTests : NCalcTest
 	[InlineData("-n", new[] { 1.3, 1.2, 1.1 })]
 	public void OrderBy_SingleTermDoubles_Succeeds(string expression, double[] expectedOrder)
 		=> new ExtendedExpression($"orderBy(list(1.2, 1.1, 1.3), 'n', '{expression}')")
-		.Evaluate()
+		.Evaluate(TestContext.Current.CancellationToken)
 		.Should()
 		.BeEquivalentTo(expectedOrder, options => options.WithStrictOrdering());
 
@@ -27,7 +27,7 @@ public class OrderByTests : NCalcTest
 	[InlineData("-n", new[] { 5, 1.3, 1.2, 0 })]
 	public void OrderBy_SingleTermMixedIntsAndDoubles(string expression, double[] expectedOrder)
 		=> new ExtendedExpression($"orderBy(list(1.2, 5, 0, 1.3), 'n', '{expression}')")
-		.Evaluate()
+		.Evaluate(TestContext.Current.CancellationToken)
 		.Should()
 		.BeEquivalentTo(expectedOrder, options => options.WithStrictOrdering());
 
@@ -35,7 +35,7 @@ public class OrderByTests : NCalcTest
 	[InlineData("n % 32", "n % 2", new[] { 34, 2, 33, 1 })]
 	public void OrderBy_MultipleTerms_Succeeds(string expression1, string expression2, int[] expectedOrder)
 		=> new ExtendedExpression($"orderBy(list(34, 33, 2, 1), 'n', '{expression1}', '{expression2}')")
-		.Evaluate()
+		.Evaluate(TestContext.Current.CancellationToken)
 		.Should()
 		.BeEquivalentTo(expectedOrder, options => options.WithStrictOrdering());
 
@@ -44,7 +44,7 @@ public class OrderByTests : NCalcTest
 	public void OrderBy_TwoSortKeys_SortsCorrectly()
 	{
 		var expression = new ExtendedExpression("orderBy(list(jObject('a', 1, 'b', 2), jObject('a', 1, 'b', 1), jObject('a', 2, 'b', 1)), 'x', 'getProperty(x, \"a\")', 'getProperty(x, \"b\")')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 	}
@@ -59,7 +59,7 @@ public class OrderByTests : NCalcTest
 			new { a = 1, b = 2, c = 1 },
 			new { a = 1, b = 1, c = 2 }
 		};
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 	}
@@ -68,14 +68,14 @@ public class OrderByTests : NCalcTest
 	public void OrderBy_Strings_SortsAlphabetically()
 	{
 		var expression = new ExtendedExpression("orderBy(list('zebra', 'apple', 'banana'), 's', 's')");
-		expression.Evaluate().Should().BeEquivalentTo(new[] { "apple", "banana", "zebra" }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new[] { "apple", "banana", "zebra" }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void OrderBy_EmptyList_ReturnsEmptyList()
 	{
 		var expression = new ExtendedExpression("orderBy(list(), 'n', 'n')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().BeEmpty();
 	}
@@ -84,14 +84,14 @@ public class OrderByTests : NCalcTest
 	public void OrderBy_SingleItem_ReturnsSingleItem()
 	{
 		var expression = new ExtendedExpression("orderBy(list(42), 'n', 'n')");
-		expression.Evaluate().Should().BeEquivalentTo(new[] { 42 });
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new[] { 42 });
 	}
 
 	[Fact]
 	public void OrderBy_WithNulls_HandlesNulls()
 	{
 		var expression = new ExtendedExpression("orderBy(list(3, null, 1, null, 2), 'n', 'n')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(5);
 		// Nulls should sort first
@@ -103,7 +103,7 @@ public class OrderByTests : NCalcTest
 	public void OrderBy_ComplexLambda_Works()
 	{
 		var expression = new ExtendedExpression("orderBy(list(5, 3, 8, 1), 'n', 'n * -1')");
-		expression.Evaluate().Should().BeEquivalentTo(new[] { 8, 5, 3, 1 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new[] { 8, 5, 3, 1 }, options => options.WithStrictOrdering());
 	}
 
 	// Error cases
@@ -111,7 +111,7 @@ public class OrderByTests : NCalcTest
 	public void OrderBy_NullList_ThrowsException()
 	{
 		var expression = new ExtendedExpression("orderBy(null, 'n', 'n')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*must be an IEnumerable*");
 	}
@@ -120,7 +120,7 @@ public class OrderByTests : NCalcTest
 	public void OrderBy_InvalidPredicate_ThrowsException()
 	{
 		var expression = new ExtendedExpression("orderBy(list(1, 2, 3), null, 'n')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*parameter must be a string*");
 	}
@@ -129,7 +129,7 @@ public class OrderByTests : NCalcTest
 	public void OrderBy_InvalidLambda_ThrowsException()
 	{
 		var expression = new ExtendedExpression("orderBy(list(1, 2, 3), 'n', null)");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("*parameter must be a string*");
 	}
@@ -140,7 +140,7 @@ public class OrderByTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("orderBy(myList, 'n', 'n')");
 		expression.Parameters["myList"] = new List<object?> { (byte)255, (byte)1, (byte)128 };
-		expression.Evaluate().Should().BeEquivalentTo(new object[] { (byte)1, (byte)128, (byte)255 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new object[] { (byte)1, (byte)128, (byte)255 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
@@ -148,7 +148,7 @@ public class OrderByTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("orderBy(myList, 'n', 'n')");
 		expression.Parameters["myList"] = new List<object?> { (sbyte)127, (sbyte)-128, (sbyte)0 };
-		expression.Evaluate().Should().BeEquivalentTo(new object[] { (sbyte)-128, (sbyte)0, (sbyte)127 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new object[] { (sbyte)-128, (sbyte)0, (sbyte)127 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
@@ -156,7 +156,7 @@ public class OrderByTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("orderBy(myList, 'n', 'n')");
 		expression.Parameters["myList"] = new List<object?> { (short)32767, (short)-100, (short)0 };
-		expression.Evaluate().Should().BeEquivalentTo(new object[] { (short)-100, (short)0, (short)32767 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new object[] { (short)-100, (short)0, (short)32767 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
@@ -164,7 +164,7 @@ public class OrderByTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("orderBy(myList, 'n', 'n')");
 		expression.Parameters["myList"] = new List<object?> { (ushort)65535, (ushort)1, (ushort)100 };
-		expression.Evaluate().Should().BeEquivalentTo(new object[] { (ushort)1, (ushort)100, (ushort)65535 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new object[] { (ushort)1, (ushort)100, (ushort)65535 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
@@ -172,7 +172,7 @@ public class OrderByTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("orderBy(myList, 'n', 'n')");
 		expression.Parameters["myList"] = new List<object?> { 4294967295u, 1u, 100u };
-		expression.Evaluate().Should().BeEquivalentTo(new object[] { 1u, 100u, 4294967295u }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new object[] { 1u, 100u, 4294967295u }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
@@ -180,7 +180,7 @@ public class OrderByTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("orderBy(myList, 'n', 'n')");
 		expression.Parameters["myList"] = new List<object?> { 9223372036854775807L, -1000L, 0L };
-		expression.Evaluate().Should().BeEquivalentTo(new object[] { -1000L, 0L, 9223372036854775807L }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new object[] { -1000L, 0L, 9223372036854775807L }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
@@ -188,7 +188,7 @@ public class OrderByTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("orderBy(myList, 'n', 'n')");
 		expression.Parameters["myList"] = new List<object?> { 18446744073709551615UL, 1UL, 100UL };
-		expression.Evaluate().Should().BeEquivalentTo(new object[] { 1UL, 100UL, 18446744073709551615UL }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new object[] { 1UL, 100UL, 18446744073709551615UL }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
@@ -196,7 +196,7 @@ public class OrderByTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("orderBy(myList, 'n', 'n')");
 		expression.Parameters["myList"] = new List<object?> { 3.3f, 1.1f, 2.2f };
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 		((float)result![0]!).Should().BeApproximately(1.1f, 0.01f);
@@ -209,7 +209,7 @@ public class OrderByTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("orderBy(myList, 'n', 'n')");
 		expression.Parameters["myList"] = new List<object?> { 3.3m, 1.1m, 2.2m };
-		expression.Evaluate().Should().BeEquivalentTo(new object[] { 1.1m, 2.2m, 3.3m }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new object[] { 1.1m, 2.2m, 3.3m }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
@@ -217,7 +217,7 @@ public class OrderByTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("orderBy(myList, 'n', 'n')");
 		expression.Parameters["myList"] = new List<object?> { 3, 1.5, (byte)2, 4L };
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(4);
 		// Should be sorted as 1.5, 2, 3, 4
@@ -227,7 +227,7 @@ public class OrderByTests : NCalcTest
 	public void OrderBy_StringsDescending_Works()
 	{
 		var expression = new ExtendedExpression("orderBy(list('apple', 'zebra', 'banana'), 's', 's')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result![0].Should().Be("apple");
 		result[2].Should().Be("zebra");
@@ -238,7 +238,7 @@ public class OrderByTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("orderBy(myList, 'x', 'x')");
 		expression.Parameters["myList"] = new List<object?> { "zebra", "apple", "banana" };
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 	}
@@ -247,7 +247,7 @@ public class OrderByTests : NCalcTest
 	public void OrderBy_FourSortKeys_Works()
 	{
 		var expression = new ExtendedExpression("orderBy(list(4, 3, 2, 1), 'n', 'n % 2', 'n % 3', 'n % 5', 'n')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(4);
 	}
@@ -257,7 +257,7 @@ public class OrderByTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("orderBy(myList, 'b', 'b')");
 		expression.Parameters["myList"] = new List<object?> { true, false, true, false };
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(4);
 		// false < true in default comparison
@@ -273,7 +273,7 @@ public class OrderByTests : NCalcTest
 		var dt2 = new System.DateTime(2021, 1, 1);
 		var dt3 = new System.DateTime(2019, 1, 1);
 		expression.Parameters["myList"] = new List<object?> { dt2, dt1, dt3 };
-		expression.Evaluate().Should().BeEquivalentTo(new object[] { dt3, dt1, dt2 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new object[] { dt3, dt1, dt2 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
@@ -281,7 +281,7 @@ public class OrderByTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("orderBy(myList, 'n', 'n')");
 		expression.Parameters["myList"] = new List<object?> { 5, null, 3, null, 1 };
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(5);
 		result![0].Should().BeNull();
@@ -293,7 +293,7 @@ public class OrderByTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("orderBy(myList, 'n', 'n')");
 		expression.Parameters["myList"] = new List<object?> { null, null, null };
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 		result.Should().OnlyContain(x => x == null);
@@ -303,27 +303,27 @@ public class OrderByTests : NCalcTest
 	public void OrderBy_LargeList_Works()
 	{
 		var expression = new ExtendedExpression("orderBy(list(10, 9, 8, 7, 6, 5, 4, 3, 2, 1), 'n', 'n')");
-		expression.Evaluate().Should().BeEquivalentTo(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void OrderBy_AllSameValues_ReturnsInOriginalOrder()
 	{
 		var expression = new ExtendedExpression("orderBy(list(5, 5, 5, 5), 'n', 'n')");
-		expression.Evaluate().Should().BeEquivalentTo(new[] { 5, 5, 5, 5 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new[] { 5, 5, 5, 5 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void OrderBy_ChainedWithSelect_Works()
 	{
 		var expression = new ExtendedExpression("orderBy(select(list(1, 2, 3), 'n', 'n * 2'), 'n', '-n')");
-		expression.Evaluate().Should().BeEquivalentTo(new[] { 6, 4, 2 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new[] { 6, 4, 2 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void OrderBy_ChainedWithWhere_Works()
 	{
 		var expression = new ExtendedExpression("orderBy(where(list(5, 2, 8, 1, 9), 'n', 'n > 3'), 'n', 'n')");
-		expression.Evaluate().Should().BeEquivalentTo(new[] { 5, 8, 9 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new[] { 5, 8, 9 }, options => options.WithStrictOrdering());
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/PadLeftTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/PadLeftTests.cs
@@ -6,34 +6,34 @@ public class PadLeftTests
 	public void PadLeft_EmptyString_SucceedsWithPaddedString()
 	{
 		var expression = new ExtendedExpression("padLeft('', 1, '0')");
-		(expression.Evaluate() as string).Should().Be("0");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("0");
 	}
 
 	[Fact]
 	public void PadLeft_DesiredLengthGreaterThanInput_SucceedsWithPaddedString()
 	{
 		var expression = new ExtendedExpression("padLeft('12', 5, '0')");
-		(expression.Evaluate() as string).Should().Be("00012");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("00012");
 	}
 
 	[Fact]
 	public void PadLeft_DesiredLengthEqualToInput_SucceedsWithOriginalString()
 	{
 		var expression = new ExtendedExpression("padLeft('12345', 5, '0')");
-		(expression.Evaluate() as string).Should().Be("12345");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("12345");
 	}
 
 	[Fact]
 	public void PadLeft_DesiredLengthLessThanInput_SucceedsWithOriginalString()
 	{
 		var expression = new ExtendedExpression("padLeft('12345', 2, '0')");
-		(expression.Evaluate() as string).Should().Be("12345");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("12345");
 	}
 
 	[Fact]
 	public void PadLeft_DesiredStringLengthTooLow_FailsAsExpected()
 		=> new ExtendedExpression("padLeft('12345', 0, '0')")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<NCalcExtensionsException>()
 			.WithMessage("padLeft() requires a DesiredStringLength for parameter 2 that is >= 1.");
@@ -41,7 +41,7 @@ public class PadLeftTests
 	[Fact]
 	public void PadLeft_PaddingStringTooLong_FailsAsExpected()
 		=> new ExtendedExpression("padLeft('12345', 5, '00')")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<NCalcExtensionsException>()
 			.WithMessage("padLeft() requires a single character string for parameter 3.");
@@ -49,7 +49,7 @@ public class PadLeftTests
 	[Fact]
 	public void PadLeft_PaddingStringEmpty_FailsAsExpected()
 		=> new ExtendedExpression("padLeft('12345', 5, '')")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<NCalcExtensionsException>()
 			.WithMessage("padLeft() requires a single character string for parameter 3.");
@@ -57,7 +57,7 @@ public class PadLeftTests
 	[Fact]
 	public void PadLeft_NullInput_ThrowsException()
 		=> new ExtendedExpression("padLeft(null, 5, '0')")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*string Input*integer DesiredStringLength*");
@@ -65,7 +65,7 @@ public class PadLeftTests
 	[Fact]
 	public void PadLeft_NonIntegerLength_ThrowsException()
 		=> new ExtendedExpression("padLeft('test', 'abc', '0')")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*integer DesiredStringLength*");
@@ -73,7 +73,7 @@ public class PadLeftTests
 	[Fact]
 	public void PadLeft_NullPaddingCharacter_ThrowsException()
 		=> new ExtendedExpression("padLeft('test', 5, null)")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<NCalcExtensionsException>()
 			.WithMessage("*parameter 3 be a string*");

--- a/PanoramicData.NCalcExtensions.Test/PanoramicData.NCalcExtensions.Test.csproj
+++ b/PanoramicData.NCalcExtensions.Test/PanoramicData.NCalcExtensions.Test.csproj
@@ -36,4 +36,10 @@
 		<ProjectReference Include="..\PanoramicData.NCalcExtensions\PanoramicData.NCalcExtensions.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <None Update="xunit.runner.json">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </None>
+	</ItemGroup>
+
 </Project>

--- a/PanoramicData.NCalcExtensions.Test/ParameterTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/ParameterTests.cs
@@ -7,6 +7,6 @@ public class ParameterTests
 	{
 		var expression = new ExtendedExpression("[a.b]");
 		expression.Parameters["a.b"] = "AAAA";
-		(expression.Evaluate() as string).Should().Be("AAAA");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("AAAA");
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/ParseIntTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/ParseIntTests.cs
@@ -14,7 +14,7 @@ public class ParseIntTests
 	public void ParseInt_ValidInput_ReturnsExpectedValue(string input, int expected)
 	{
 		var expression = new ExtendedExpression($"parseInt({input})");
-		expression.Evaluate().Should().Be(expected);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(expected);
 	}
 
 	[Theory]
@@ -30,7 +30,7 @@ public class ParseIntTests
 	[InlineData("parseInt('0xFF')")]
 	[InlineData("parseInt(null)")]
 	public void ParseInt_InvalidInput_ThrowsException(string expression) => new ExtendedExpression(expression)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>();
 
 	[Fact]
@@ -38,28 +38,28 @@ public class ParseIntTests
 	{
 		var expression = new ExtendedExpression("parseInt(myValue)");
 		expression.Parameters["myValue"] = "123";
-		expression.Evaluate().Should().Be(123);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(123);
 	}
 
 	[Fact]
 	public void ParseInt_InExpression_Works()
 	{
 		var expression = new ExtendedExpression("parseInt('10') + parseInt('20')");
-		expression.Evaluate().Should().Be(30);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(30);
 	}
 
 	[Fact]
 	public void ParseInt_InComparison_Works()
 	{
 		var expression = new ExtendedExpression("parseInt('42') > 40");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void ParseInt_InList_Works()
 	{
 		var expression = new ExtendedExpression("list(parseInt('1'), parseInt('2'), parseInt('3'))");
-		var result = expression.Evaluate() as System.Collections.Generic.List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as System.Collections.Generic.List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 	}

--- a/PanoramicData.NCalcExtensions.Test/ParseJsonDocumentTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/ParseJsonDocumentTests.cs
@@ -11,7 +11,7 @@ public class ParseJsonDocumentTests
 	public void Parse_JsonDocument_Succeeds(string json)
 	{
 		var expression = new ExtendedExpression($"parse('JsonDocument', '{json}')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<JsonDocument>();
 		
 		var jsonDoc = result as JsonDocument;
@@ -26,7 +26,7 @@ public class ParseJsonDocumentTests
 	public void Parse_JsonArray_Succeeds(string json)
 	{
 		var expression = new ExtendedExpression($"parse('JsonArray', '{json}')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<JsonDocument>();
 		
 		var jsonDoc = result as JsonDocument;
@@ -40,7 +40,7 @@ public class ParseJsonDocumentTests
 	public void Parse_JsonDocument_VariousTypeNames_Succeeds(string typeName)
 	{
 		var expression = new ExtendedExpression($"parse('{typeName}', '{{\"test\":123}}')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<JsonDocument>();
 	}
 
@@ -49,7 +49,7 @@ public class ParseJsonDocumentTests
 	public void Parse_JsonArray_VariousTypeNames_Succeeds(string typeName)
 	{
 		var expression = new ExtendedExpression($"parse('{typeName}', '[1,2,3]')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<JsonDocument>();
 		
 		var jsonDoc = result as JsonDocument;
@@ -60,7 +60,7 @@ public class ParseJsonDocumentTests
 	public void Parse_JsonDocument_InvalidJson_ThrowsException()
 	{
 		var expression = new ExtendedExpression("parse('JsonDocument', '{invalid json}')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>();
 	}
 
@@ -68,7 +68,7 @@ public class ParseJsonDocumentTests
 	public void Parse_JsonArray_ObjectInstead_ThrowsException()
 	{
 		var expression = new ExtendedExpression("parse('JsonArray', '{\"not\":\"array\"}')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>();
 	}
 
@@ -76,7 +76,7 @@ public class ParseJsonDocumentTests
 	public void Parse_JsonDocument_WithFallback_ReturnsFallback()
 	{
 		var expression = new ExtendedExpression("parse('JsonDocument', '{invalid}', 'fallback')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be("fallback");
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/ParseTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/ParseTests.cs
@@ -12,7 +12,7 @@ public class ParseTests
 	[InlineData("1")]
 	public void Parse_IncorrectParameterCountOrType_Throws(string parameters)
 		=> new ExtendedExpression($"parse({parameters})")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<FormatException>();
 
@@ -33,7 +33,7 @@ public class ParseTests
 	[InlineData("Guid")]
 	public void Parse_DoesNotParse_Throws(string parameters)
 		=> new ExtendedExpression($"parse('{parameters}', 'x')")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<FormatException>();
 
@@ -45,11 +45,11 @@ public class ParseTests
 	public void Parse_Bool_Succeeds(string text)
 	{
 		new ExtendedExpression($"parse('bool', '{text}')")
-				.Evaluate()
+				.Evaluate(TestContext.Current.CancellationToken)
 				.Should().Be(bool.Parse(text));
 
 		new ExtendedExpression($"parse('System.Boolean', '{text}')")
-			.Evaluate()
+			.Evaluate(TestContext.Current.CancellationToken)
 			.Should().Be(bool.Parse(text));
 	}
 
@@ -62,7 +62,7 @@ public class ParseTests
 	{
 		var expression = new ExtendedExpression($"parse('bool', a, null)");
 		expression.Parameters["a"] = text;
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeNull();
 	}
 
@@ -73,10 +73,10 @@ public class ParseTests
 	[InlineData("0")]
 	public void Parse_Int_Succeeds(string text)
 	{
-		var result = new ExtendedExpression($"parse('int', '{text}')").Evaluate();
+		var result = new ExtendedExpression($"parse('int', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(int.Parse(text, CultureInfo.InvariantCulture));
 
-		result = new ExtendedExpression($"parse('System.Int32', '{text}')").Evaluate();
+		result = new ExtendedExpression($"parse('System.Int32', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(int.Parse(text, CultureInfo.InvariantCulture));
 	}
 
@@ -89,9 +89,9 @@ public class ParseTests
 	[InlineData("{fa2e60e8-dd1e-AAAA-b53c-e69c63f14866}")] // Mixed case with curlies
 	public void Parse_Guid_Succeeds(string text)
 	{
-		var result = new ExtendedExpression($"parse('Guid', '{text}')").Evaluate();
+		var result = new ExtendedExpression($"parse('Guid', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(Guid.Parse(text));
-		result = new ExtendedExpression($"parse('System.Guid', '{text}')").Evaluate();
+		result = new ExtendedExpression($"parse('System.Guid', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(Guid.Parse(text));
 	}
 
@@ -102,10 +102,10 @@ public class ParseTests
 	[InlineData("0")]
 	public void Parse_Long_Succeeds(string text)
 	{
-		var result = new ExtendedExpression($"parse('long', '{text}')").Evaluate();
+		var result = new ExtendedExpression($"parse('long', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(long.Parse(text, CultureInfo.InvariantCulture));
 
-		result = new ExtendedExpression($"parse('System.Int64', '{text}')").Evaluate();
+		result = new ExtendedExpression($"parse('System.Int64', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(long.Parse(text, CultureInfo.InvariantCulture));
 	}
 
@@ -114,10 +114,10 @@ public class ParseTests
 	[InlineData("0")]
 	public void Parse_ULong_Succeeds(string text)
 	{
-		var result = new ExtendedExpression($"parse('ulong', '{text}')").Evaluate();
+		var result = new ExtendedExpression($"parse('ulong', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(ulong.Parse(text, CultureInfo.InvariantCulture));
 
-		result = new ExtendedExpression($"parse('System.UInt64', '{text}')").Evaluate();
+		result = new ExtendedExpression($"parse('System.UInt64', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(ulong.Parse(text, CultureInfo.InvariantCulture));
 	}
 
@@ -126,10 +126,10 @@ public class ParseTests
 	[InlineData("0")]
 	public void Parse_UInt_Succeeds(string text)
 	{
-		var result = new ExtendedExpression($"parse('uint', '{text}')").Evaluate();
+		var result = new ExtendedExpression($"parse('uint', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(uint.Parse(text, CultureInfo.InvariantCulture));
 
-		result = new ExtendedExpression($"parse('System.UInt32', '{text}')").Evaluate();
+		result = new ExtendedExpression($"parse('System.UInt32', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(uint.Parse(text, CultureInfo.InvariantCulture));
 	}
 
@@ -140,10 +140,10 @@ public class ParseTests
 	[InlineData("0")]
 	public void Parse_Double_Succeeds(string text)
 	{
-		var result = new ExtendedExpression($"parse('double', '{text}')").Evaluate();
+		var result = new ExtendedExpression($"parse('double', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(double.Parse(text, CultureInfo.InvariantCulture));
 
-		result = new ExtendedExpression($"parse('System.Double', '{text}')").Evaluate();
+		result = new ExtendedExpression($"parse('System.Double', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(double.Parse(text, CultureInfo.InvariantCulture));
 	}
 
@@ -154,10 +154,10 @@ public class ParseTests
 	[InlineData("0")]
 	public void Parse_Float_Succeeds(string text)
 	{
-		var result = new ExtendedExpression($"parse('float', '{text}')").Evaluate();
+		var result = new ExtendedExpression($"parse('float', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(float.Parse(text, CultureInfo.InvariantCulture));
 
-		result = new ExtendedExpression($"parse('System.Single', '{text}')").Evaluate();
+		result = new ExtendedExpression($"parse('System.Single', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(float.Parse(text, CultureInfo.InvariantCulture));
 	}
 
@@ -168,10 +168,10 @@ public class ParseTests
 	[InlineData("0")]
 	public void Parse_Decimal_Succeeds(string text)
 	{
-		var result = new ExtendedExpression($"parse('decimal', '{text}')").Evaluate();
+		var result = new ExtendedExpression($"parse('decimal', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(decimal.Parse(text, CultureInfo.InvariantCulture));
 
-		result = new ExtendedExpression($"parse('System.Decimal', '{text}')").Evaluate();
+		result = new ExtendedExpression($"parse('System.Decimal', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(decimal.Parse(text, CultureInfo.InvariantCulture));
 	}
 
@@ -182,10 +182,10 @@ public class ParseTests
 	[InlineData("0")]
 	public void Parse_SByte_Succeeds(string text)
 	{
-		var result = new ExtendedExpression($"parse('sbyte', '{text}')").Evaluate();
+		var result = new ExtendedExpression($"parse('sbyte', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(sbyte.Parse(text, CultureInfo.InvariantCulture));
 
-		result = new ExtendedExpression($"parse('System.SByte', '{text}')").Evaluate();
+		result = new ExtendedExpression($"parse('System.SByte', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(sbyte.Parse(text, CultureInfo.InvariantCulture));
 	}
 
@@ -194,10 +194,10 @@ public class ParseTests
 	[InlineData("0")]
 	public void Parse_Byte_Succeeds(string text)
 	{
-		var result = new ExtendedExpression($"parse('byte', '{text}')").Evaluate();
+		var result = new ExtendedExpression($"parse('byte', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(byte.Parse(text, CultureInfo.InvariantCulture));
 
-		result = new ExtendedExpression($"parse('System.Byte', '{text}')").Evaluate();
+		result = new ExtendedExpression($"parse('System.Byte', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(byte.Parse(text, CultureInfo.InvariantCulture));
 	}
 
@@ -208,10 +208,10 @@ public class ParseTests
 	[InlineData("0")]
 	public void Parse_Short_Succeeds(string text)
 	{
-		var result = new ExtendedExpression($"parse('short', '{text}')").Evaluate();
+		var result = new ExtendedExpression($"parse('short', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(short.Parse(text, CultureInfo.InvariantCulture));
 
-		result = new ExtendedExpression($"parse('System.Int16', '{text}')").Evaluate();
+		result = new ExtendedExpression($"parse('System.Int16', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(short.Parse(text, CultureInfo.InvariantCulture));
 	}
 
@@ -220,10 +220,10 @@ public class ParseTests
 	[InlineData("0")]
 	public void Parse_Ushort_Succeeds(string text)
 	{
-		var result = new ExtendedExpression($"parse('ushort', '{text}')").Evaluate();
+		var result = new ExtendedExpression($"parse('ushort', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(ushort.Parse(text, CultureInfo.InvariantCulture));
 
-		result = new ExtendedExpression($"parse('System.UInt16', '{text}')").Evaluate();
+		result = new ExtendedExpression($"parse('System.UInt16', '{text}')").Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(ushort.Parse(text, CultureInfo.InvariantCulture));
 	}
 
@@ -233,7 +233,7 @@ public class ParseTests
 	public void Parse_JObject_Succeeds(string text)
 	{
 		var expression = new ExtendedExpression($"parse('jObject', '{text}')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		JsonConvert.SerializeObject(result).Should().Be(text);
 	}
 
@@ -243,7 +243,7 @@ public class ParseTests
 	public void Parse_JArray_Succeeds(string text)
 	{
 		var expression = new ExtendedExpression($"parse('jArray', '{text}')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		JsonConvert.SerializeObject(result).Should().Be(text);
 	}
 
@@ -253,7 +253,7 @@ public class ParseTests
 	public void Parse_CapitalJ_JObject_Succeeds(string text)
 	{
 		var expression = new ExtendedExpression($"parse('JObject', '{text}')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		JsonConvert.SerializeObject(result).Should().Be(text);
 	}
 
@@ -263,7 +263,7 @@ public class ParseTests
 	public void Parse_CapitalJ_JArray_Succeeds(string text)
 	{
 		var expression = new ExtendedExpression($"parse('JArray', '{text}')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		JsonConvert.SerializeObject(result).Should().Be(text);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/RegexGroupTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/RegexGroupTests.cs
@@ -37,7 +37,7 @@ public class RegexGroupTests : NCalcTest
 		var text = "AutoTask: xxx.xxx@xxx.com at 2022-05-10 08:26:57 UTC (37407238)\nTitle: Notification Description: xxx@xxx.xxx";
 		var expression = new ExtendedExpression("regexGroup(text, 'AutoTask: .+ \\\\((\\\\d+)\\\\)\\\\n')");
 		expression.Parameters["text"] = text;
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().Be("37407238");
 	}
@@ -54,7 +54,7 @@ public class RegexGroupTests : NCalcTest
 	public void RegexGroup_NullInput_ThrowsException()
 	{
 		var expression = new ExtendedExpression("regexGroup(null, 'pattern')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*requires string parameters*");
 	}
 
@@ -62,7 +62,7 @@ public class RegexGroupTests : NCalcTest
 	public void RegexGroup_NullPattern_ThrowsException()
 	{
 		var expression = new ExtendedExpression("regexGroup('text', null)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*requires string parameters*");
 	}
 
@@ -70,7 +70,7 @@ public class RegexGroupTests : NCalcTest
 	public void RegexGroup_NonStringInput_ThrowsException()
 	{
 		var expression = new ExtendedExpression("regexGroup(123, 'pattern')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*requires string parameters*");
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/ReplaceTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/ReplaceTests.cs
@@ -6,21 +6,21 @@ public class ReplaceTests
 	public void Replace_Example1_Succeeds()
 	{
 		var expression = new ExtendedExpression("replace('abcdefg', 'cde', 'CDE')");
-		(expression.Evaluate() as string).Should().Be("abCDEfg");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("abCDEfg");
 	}
 
 	[Fact]
 	public void Replace_Example2_Succeeds()
 	{
 		var expression = new ExtendedExpression("replace('abcdefg', 'cde', '')");
-		(expression.Evaluate() as string).Should().Be("abfg");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("abfg");
 	}
 
 	[Fact]
 	public void Replace_Example3_Succeeds()
 	{
 		var expression = new ExtendedExpression("replace('abcdefg', 'a', '1', 'bc', '23')");
-		(expression.Evaluate() as string).Should().Be("123defg");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("123defg");
 	}
 
 	// Additional comprehensive tests
@@ -29,21 +29,21 @@ public class ReplaceTests
 	public void Replace_NoMatch_ReturnsOriginal()
 	{
 		var expression = new ExtendedExpression("replace('abcdefg', 'xyz', 'XYZ')");
-		expression.Evaluate().Should().Be("abcdefg");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("abcdefg");
 	}
 
 	[Fact]
 	public void Replace_MultipleOccurrences_ReplacesAll()
 	{
 		var expression = new ExtendedExpression("replace('banana', 'a', 'o')");
-		expression.Evaluate().Should().Be("bonono");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("bonono");
 	}
 
 	[Fact]
 	public void Replace_EmptyString_ReturnsEmpty()
 	{
 		var expression = new ExtendedExpression("replace('', 'a', 'b')");
-		expression.Evaluate().Should().Be("");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("");
 	}
 
 	[Fact]
@@ -51,7 +51,7 @@ public class ReplaceTests
 	{
 		var expression = new ExtendedExpression("replace('abc', '', 'X')");
 		// Empty oldValue throws an ArgumentException in string.Replace
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<Exception>();
 	}
 
@@ -59,49 +59,49 @@ public class ReplaceTests
 	public void Replace_ReplaceWithLongerString_Succeeds()
 	{
 		var expression = new ExtendedExpression("replace('abc', 'b', 'BBB')");
-		expression.Evaluate().Should().Be("aBBBc");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("aBBBc");
 	}
 
 	[Fact]
 	public void Replace_ReplaceWithShorterString_Succeeds()
 	{
 		var expression = new ExtendedExpression("replace('abbbbc', 'bbb', 'X')");
-		expression.Evaluate().Should().Be("aXbc");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("aXbc");
 	}
 
 	[Fact]
 	public void Replace_CaseSensitive_NoMatch()
 	{
 		var expression = new ExtendedExpression("replace('ABC', 'abc', 'xyz')");
-		expression.Evaluate().Should().Be("ABC");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("ABC");
 	}
 
 	[Fact]
 	public void Replace_WholeString_Succeeds()
 	{
 		var expression = new ExtendedExpression("replace('hello', 'hello', 'goodbye')");
-		expression.Evaluate().Should().Be("goodbye");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("goodbye");
 	}
 
 	[Fact]
 	public void Replace_AtStart_Succeeds()
 	{
 		var expression = new ExtendedExpression("replace('hello world', 'hello', 'hi')");
-		expression.Evaluate().Should().Be("hi world");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("hi world");
 	}
 
 	[Fact]
 	public void Replace_AtEnd_Succeeds()
 	{
 		var expression = new ExtendedExpression("replace('hello world', 'world', 'there')");
-		expression.Evaluate().Should().Be("hello there");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("hello there");
 	}
 
 	[Fact]
 	public void Replace_MultipleReplacements_Succeeds()
 	{
 		var expression = new ExtendedExpression("replace('abc def ghi', 'a', '1', 'd', '2', 'g', '3')");
-		expression.Evaluate().Should().Be("1bc 2ef 3hi");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("1bc 2ef 3hi");
 	}
 
 	[Fact]
@@ -109,7 +109,7 @@ public class ReplaceTests
 	{
 		var expression = new ExtendedExpression("replace('abcabc', 'ab', 'X', 'bc', 'Y')");
 		// First replacement happens first, then second on the result
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().NotBeNullOrEmpty();
 	}
 
@@ -117,28 +117,28 @@ public class ReplaceTests
 	public void Replace_SpecialCharacters_Succeeds()
 	{
 		var expression = new ExtendedExpression("replace('a.b*c?d', '.', '-', '*', '+', '?', '!')");
-		expression.Evaluate().Should().Be("a-b+c!d");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("a-b+c!d");
 	}
 
 	[Fact]
 	public void Replace_Whitespace_Succeeds()
 	{
 		var expression = new ExtendedExpression("replace('a b c', ' ', '_')");
-		expression.Evaluate().Should().Be("a_b_c");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("a_b_c");
 	}
 
 	[Fact]
 	public void Replace_Tabs_Succeeds()
 	{
 		var expression = new ExtendedExpression("replace('a\tb\tc', '\t', ' ')");
-		expression.Evaluate().Should().Be("a b c");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("a b c");
 	}
 
 	[Fact]
 	public void Replace_Newlines_Succeeds()
 	{
 		var expression = new ExtendedExpression("replace('a\nb\nc', '\n', ' ')");
-		expression.Evaluate().Should().Be("a b c");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("a b c");
 	}
 
 	[Fact]
@@ -146,7 +146,7 @@ public class ReplaceTests
 	{
 		var expression = new ExtendedExpression("replace(myString, 'old', 'new')");
 		expression.Parameters["myString"] = "old value";
-		expression.Evaluate().Should().Be("new value");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("new value");
 	}
 
 	[Fact]
@@ -156,35 +156,35 @@ public class ReplaceTests
 		expression.Parameters["text"] = "hello world";
 		expression.Parameters["oldVal"] = "world";
 		expression.Parameters["newVal"] = "there";
-		expression.Evaluate().Should().Be("hello there");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("hello there");
 	}
 
 	[Fact]
 	public void Replace_ChainedReplacements_Succeeds()
 	{
 		var expression = new ExtendedExpression("replace(replace('abc', 'a', 'X'), 'b', 'Y')");
-		expression.Evaluate().Should().Be("XYc");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("XYc");
 	}
 
 	[Fact]
 	public void Replace_InConcat_Succeeds()
 	{
 		var expression = new ExtendedExpression("replace('hello', 'e', 'a') + ' world'");
-		expression.Evaluate().Should().Be("hallo world");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("hallo world");
 	}
 
 	[Fact]
 	public void Replace_Numbers_Succeeds()
 	{
 		var expression = new ExtendedExpression("replace('123456', '3', 'X')");
-		expression.Evaluate().Should().Be("12X456");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("12X456");
 	}
 
 	[Fact]
 	public void Replace_RepeatingPattern_Succeeds()
 	{
 		var expression = new ExtendedExpression("replace('aaabbbccc', 'aaa', 'A', 'bbb', 'B', 'ccc', 'C')");
-		expression.Evaluate().Should().Be("ABC");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("ABC");
 	}
 
 	// Error cases
@@ -192,7 +192,7 @@ public class ReplaceTests
 	public void Replace_OddNumberOfParameters_ThrowsException()
 	{
 		var expression = new ExtendedExpression("replace('abc', 'a')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>();
 	}
 
@@ -200,7 +200,7 @@ public class ReplaceTests
 	public void Replace_NoParameters_ThrowsException()
 	{
 		var expression = new ExtendedExpression("replace()");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>();
 	}
 
@@ -208,7 +208,7 @@ public class ReplaceTests
 	public void Replace_OneParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("replace('abc')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>();
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/SanitizeTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/SanitizeTests.cs
@@ -13,7 +13,7 @@ public class SanitizeTests
 	{
 		var expression = new ExtendedExpression($"sanitize({inputString}, {allowedCharacters})");
 
-		var action = expression.Evaluate;
+		var action = () => expression.Evaluate(TestContext.Current.CancellationToken);
 
 		action.Should().Throw<FormatException>();
 	}
@@ -27,7 +27,7 @@ public class SanitizeTests
 	{
 		var expression = new ExtendedExpression($"sanitize({inputString}, {allowedCharacters}, {replacementCharacters})");
 
-		var action = expression.Evaluate;
+		var action = () => expression.Evaluate(TestContext.Current.CancellationToken);
 
 		action.Should().Throw<FormatException>();
 	}
@@ -46,7 +46,7 @@ public class SanitizeTests
 	{
 		var expression = new ExtendedExpression($"sanitize({inputString}, {allowedCharacters})");
 
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().Be(expectedResult);
 	}
@@ -71,7 +71,7 @@ public class SanitizeTests
 	{
 		var expression = new ExtendedExpression($"sanitize({inputString}, {allowedCharacters}, {replacementCharacters})");
 
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().Be(expectedResult);
 	}

--- a/PanoramicData.NCalcExtensions.Test/SelectDistinctTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/SelectDistinctTests.cs
@@ -8,7 +8,7 @@ public class SelectDistinctTests : NCalcTest
 	public void SelectDistinct_Succeeds()
 	{
 		var result = new ExtendedExpression($"selectDistinct(list(1, 2, 3, 3, 3), 'n', 'n + 1')")
-			.Evaluate();
+			.Evaluate(TestContext.Current.CancellationToken);
 
 		// The result should be 4, 5, 6
 		result.Should().NotBeNull();

--- a/PanoramicData.NCalcExtensions.Test/SelectTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/SelectTests.cs
@@ -8,7 +8,7 @@ public class SelectTests : NCalcTest
 	public void Select_Succeeds()
 	{
 		var result = new ExtendedExpression($"select(list(1, 2, 3, 4, 5), 'n', 'n + 1')")
-			.Evaluate();
+			.Evaluate(TestContext.Current.CancellationToken);
 
 		// The result should be 2, 3, 4, 5, 6
 		result.Should().NotBeNull();
@@ -19,7 +19,7 @@ public class SelectTests : NCalcTest
 	public void Select_IntoJObjects_Succeeds()
 	{
 		var result = new ExtendedExpression($"select(list(jObject('a', 1, 'b', '2'), jObject('a', 3, 'b', '4')), 'n', 'n', 'JObject')")
-			.Evaluate();
+			.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().NotBeNull();
 		result.Should().BeOfType<List<JObject>>();
@@ -29,7 +29,7 @@ public class SelectTests : NCalcTest
 	[Fact]
 	public void Select_NullFirstParameter_ThrowsException()
 		=> new ExtendedExpression("select(null, 'n', 'n + 1')")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*First*must be an IList*");
@@ -37,7 +37,7 @@ public class SelectTests : NCalcTest
 	[Fact]
 	public void Select_NonListFirstParameter_ThrowsException()
 		=> new ExtendedExpression("select(123, 'n', 'n + 1')")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*First*must be an IList*");
@@ -45,7 +45,7 @@ public class SelectTests : NCalcTest
 	[Fact]
 	public void Select_NullSecondParameter_ThrowsException()
 		=> new ExtendedExpression("select(list(1,2,3), null, 'n + 1')")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*Second*must be a string*");
@@ -53,7 +53,7 @@ public class SelectTests : NCalcTest
 	[Fact]
 	public void Select_NullThirdParameter_ThrowsException()
 		=> new ExtendedExpression("select(list(1,2,3), 'n', null)")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*Third*must be a string*");
@@ -61,7 +61,7 @@ public class SelectTests : NCalcTest
 	[Fact]
 	public void Select_InvalidFourthParameter_ThrowsException()
 		=> new ExtendedExpression("select(list(1,2,3), 'n', 'n', 'InvalidType')")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*Fourth*must be either 'object'*or 'JObject'*");
@@ -69,7 +69,7 @@ public class SelectTests : NCalcTest
 	[Fact]
 	public void Select_NonStringFourthParameter_ThrowsException()
 		=> new ExtendedExpression("select(list(1,2,3), 'n', 'n', 123)")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*Fourth*must be a string*");
@@ -79,7 +79,7 @@ public class SelectTests : NCalcTest
 	public void Select_EmptyList_ReturnsEmptyList()
 	{
 		var result = new ExtendedExpression("select(list(), 'n', 'n + 1')")
-			.Evaluate();
+			.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().NotBeNull();
 		result.Should().BeEquivalentTo(new List<object>());
@@ -89,7 +89,7 @@ public class SelectTests : NCalcTest
 	public void Select_SingleElement_Works()
 	{
 		var result = new ExtendedExpression("select(list(5), 'n', 'n * 2')")
-			.Evaluate();
+			.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().NotBeNull();
 		result.Should().BeEquivalentTo(new List<int> { 10 });
@@ -99,7 +99,7 @@ public class SelectTests : NCalcTest
 	public void Select_Strings_Works()
 	{
 		var result = new ExtendedExpression("select(list('a', 'b', 'c'), 's', 'toUpper(s)')")
-			.Evaluate();
+			.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().NotBeNull();
 		result.Should().BeEquivalentTo(new List<string> { "A", "B", "C" });
@@ -109,7 +109,7 @@ public class SelectTests : NCalcTest
 	public void Select_WithNullInResult_Works()
 	{
 		var result = new ExtendedExpression("select(list(1, 2, 3), 'n', 'if(n == 2, null, n)')")
-			.Evaluate();
+			.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().NotBeNull();
 		var list = result as List<object?>;
@@ -121,7 +121,7 @@ public class SelectTests : NCalcTest
 	public void Select_JObject_WithNullValue_Works()
 	{
 		var result = new ExtendedExpression("select(list(1, 2, 3), 'n', 'if(n == 2, null, jObject(\"value\", n))', 'JObject')")
-			.Evaluate();
+			.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().NotBeNull();
 		result.Should().BeOfType<List<JObject?>>();
@@ -135,7 +135,7 @@ public class SelectTests : NCalcTest
 	{
 		// When converting non-JObject values, they need to be wrapped in an object first
 		var result = new ExtendedExpression("select(list(jObject('a', 1), jObject('a', 2)), 'obj', 'obj', 'JObject')")
-			.Evaluate();
+			.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().NotBeNull();
 		result.Should().BeOfType<List<JObject?>>();
@@ -149,7 +149,7 @@ public class SelectTests : NCalcTest
 	public void Select_JObject_ExplicitObjectType_Works()
 	{
 		var result = new ExtendedExpression("select(list(1, 2, 3), 'n', 'n * 2', 'object')")
-			.Evaluate();
+			.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().NotBeNull();
 		result.Should().BeEquivalentTo(new List<int> { 2, 4, 6 });
@@ -159,7 +159,7 @@ public class SelectTests : NCalcTest
 	public void Select_ComplexTransformation_Works()
 	{
 		var result = new ExtendedExpression("select(list(1, 2, 3, 4, 5), 'n', 'if(n % 2 == 0, n * 10, n)')")
-			.Evaluate();
+			.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().NotBeNull();
 		result.Should().BeEquivalentTo(new List<int> { 1, 20, 3, 40, 5 });
@@ -169,7 +169,7 @@ public class SelectTests : NCalcTest
 	public void Select_Doubles_Works()
 	{
 		var result = new ExtendedExpression("select(list(1.5, 2.5, 3.5), 'n', 'n * 2')")
-			.Evaluate();
+			.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().NotBeNull();
 		result.Should().BeEquivalentTo(new List<double> { 3.0, 5.0, 7.0 });

--- a/PanoramicData.NCalcExtensions.Test/SetPropertiesJsonDocumentTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/SetPropertiesJsonDocumentTests.cs
@@ -12,7 +12,7 @@ public class SetPropertiesJsonDocumentTests
 		var jsonDoc = JsonDocument.Parse("{\"a\": 1, \"b\": null}");
 		var expression = new ExtendedExpression("getProperty(source, 'a')");
 		expression.Parameters["source"] = jsonDoc;
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(1);
 	}
 
@@ -22,7 +22,7 @@ public class SetPropertiesJsonDocumentTests
 		// Test that anonymous objects can be converted and properties accessed similar to JObject
 		var expression = new ExtendedExpression("getProperty(anon, 'a')");
 		expression.Parameters["anon"] = new { a = 1, b = (string?)null };
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(1);
 	}
 
@@ -30,7 +30,7 @@ public class SetPropertiesJsonDocumentTests
 	public void SetProperties_JsonDocument_PropertyAccess_Succeeds()
 	{
 		var expression = new ExtendedExpression("getProperty(jsonDocument('a', 1, 'b', null, 'c', 'X'), 'c')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be("X");
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/SetPropertiesTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/SetPropertiesTests.cs
@@ -6,7 +6,7 @@ public class SetPropertiesTests
 	public void SetProperties_OnJObject_CreatesJObject()
 	{
 		var expression = new ExtendedExpression("setProperties(jObject('a', 1, 'b', null), 'c', 'X')");
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().BeOfType<JObject>();
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
@@ -22,7 +22,7 @@ public class SetPropertiesTests
 	{
 		var expression = new ExtendedExpression("setProperties(anon, 'c', 'X')");
 		expression.Parameters["anon"] = new { a = 1, b = (string?)null };
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().BeOfType<JObject>();
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
@@ -37,7 +37,7 @@ public class SetPropertiesTests
 	public void SetProperties_MultipleProperties_Succeeds()
 	{
 		var expression = new ExtendedExpression("setProperties(jObject('a', 1), 'b', 2, 'c', 3)");
-		var result = expression.Evaluate() as JObject;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as JObject;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 		result!["a"]!.Value<int>().Should().Be(1);
@@ -50,7 +50,7 @@ public class SetPropertiesTests
 	public void SetProperties_EvenNumberOfParameters_ThrowsException()
 	{
 		var expression = new ExtendedExpression("setProperties(jObject('a', 1), 'b')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*odd number of parameters*");
 	}
 
@@ -58,7 +58,7 @@ public class SetPropertiesTests
 	public void SetProperties_NullFirstParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("setProperties(null, 'key', 'value')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*first parameter cannot be null*");
 	}
 
@@ -66,7 +66,7 @@ public class SetPropertiesTests
 	public void SetProperties_NonStringKey_ThrowsException()
 	{
 		var expression = new ExtendedExpression("setProperties(jObject('a', 1), 123, 'value')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*requires a string key*");
 	}
 
@@ -74,7 +74,7 @@ public class SetPropertiesTests
 	public void SetProperties_DuplicateKey_ThrowsException()
 	{
 		var expression = new ExtendedExpression("setProperties(jObject('a', 1), 'a', 2)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*can only define property a once*");
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/Sha256Tests.cs
+++ b/PanoramicData.NCalcExtensions.Test/Sha256Tests.cs
@@ -10,14 +10,14 @@ public class Sha256Tests
 	{
 		var expression = new ExtendedExpression("sha256(x)");
 		expression.Parameters.Add("x", input);
-		expression.Evaluate().Should().Be(expectedOutput);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(expectedOutput);
 	}
 
 	[Fact]
 	public void Sha256_NullParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("sha256(null)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*string parameter*");
 	}
 
@@ -25,7 +25,7 @@ public class Sha256Tests
 	public void Sha256_NonStringParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("sha256(123)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*string parameter*");
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/SkipTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/SkipTests.cs
@@ -8,7 +8,7 @@ public class SkipTests
 	public void List_OfInts_ReturnsExpectedType()
 	{
 		var expression = new ExtendedExpression($"skip(list(1, 2, 3), 1)");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<List<object?>>();
 	}
 
@@ -17,7 +17,7 @@ public class SkipTests
 	{
 		var expression = new ExtendedExpression($"skip(theArray, 1)");
 		expression.Parameters["theArray"] = new[] { 1, 2, 3 };
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<List<object?>>();
 		result.Should().BeEquivalentTo(new List<object> { 2, 3 }, options => options.WithStrictOrdering());
 	}
@@ -26,20 +26,20 @@ public class SkipTests
 	public void List_OfInts_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression($"skip(list(1, 2, 3), 1)");
-		expression.Evaluate().Should().BeEquivalentTo(new List<object> { 2, 3 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<object> { 2, 3 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void SkippingTooMany_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression($"skip(list(1, 2, 3), 10)");
-		expression.Evaluate().Should().BeEquivalentTo(new List<object>(), options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<object>(), options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void Skip_InvalidCountParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("skip(list(1, 2, 3), 'invalid')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>();
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/SortTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/SortTests.cs
@@ -8,7 +8,7 @@ public class SortTests : NCalcTest
 	[InlineData("desc", new[] { 3, 2, 1 })]
 	public void Sort_Ints_Succeeds(string? direction, int[] expectedOrder)
 		=> new ExtendedExpression($"sort(list(2, 1, 3){(direction is null ? string.Empty : $", '{direction}'")})")
-		.Evaluate()
+		.Evaluate(TestContext.Current.CancellationToken)
 		.Should()
 		.BeEquivalentTo(expectedOrder);
 
@@ -18,7 +18,7 @@ public class SortTests : NCalcTest
 	[InlineData("desc", new[] { "3", "2", "1" })]
 	public void Sort_Strings_Succeeds(string? direction, string[] expectedOrder)
 		=> new ExtendedExpression($"sort(list('2', '1', '3'){(direction is null ? string.Empty : $", '{direction}'")})")
-		.Evaluate()
+		.Evaluate(TestContext.Current.CancellationToken)
 		.Should()
 		.BeEquivalentTo(expectedOrder);
 }

--- a/PanoramicData.NCalcExtensions.Test/SplitTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/SplitTests.cs
@@ -9,7 +9,7 @@ public class SplitTests : NCalcTest
 	[InlineData("split('a b c')")]
 	public void Split_InsufficientParameters_ThrowsException(string expression)
 		=> new ExtendedExpression(expression)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<FormatException>();
 
@@ -18,7 +18,7 @@ public class SplitTests : NCalcTest
 	[InlineData("split('x x x', '')")]
 	public void Split_EmptySecondParameter_ThrowsException(string expression)
 		=> new ExtendedExpression(expression)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<FormatException>();
 
@@ -28,7 +28,7 @@ public class SplitTests : NCalcTest
 	public void Split_ValidParameters_Succeeds(string expression)
 	{
 		var e = new ExtendedExpression(expression);
-		var result = e.Evaluate();
+		var result = e.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<List<string>>();
 		var list = (List<string>)result;
 		list.Should().HaveCount(3);
@@ -42,7 +42,7 @@ public class SplitTests : NCalcTest
 	public void Split_CommaSeparated_Works()
 	{
 		var expression = new ExtendedExpression("split('one,two,three', ',')");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().BeEquivalentTo(["one", "two", "three"], options => options.WithStrictOrdering());
 	}
@@ -51,7 +51,7 @@ public class SplitTests : NCalcTest
 	public void Split_SingleCharDelimiter_Works()
 	{
 		var expression = new ExtendedExpression("split('a|b|c|d', '|')");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(4);
 	}
@@ -60,7 +60,7 @@ public class SplitTests : NCalcTest
 	public void Split_NoDelimiterFound_ReturnsSingleItem()
 	{
 		var expression = new ExtendedExpression("split('nodivider', ',')");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(1);
 		result![0].Should().Be("nodivider");
@@ -70,7 +70,7 @@ public class SplitTests : NCalcTest
 	public void Split_EmptyString_ReturnsEmptyList()
 	{
 		var expression = new ExtendedExpression("split('', ',')");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(1);
 		result![0].Should().Be("");
@@ -80,7 +80,7 @@ public class SplitTests : NCalcTest
 	public void Split_ConsecutiveDelimiters_CreatesEmptyStrings()
 	{
 		var expression = new ExtendedExpression("split('a,,b', ',')");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 		result![1].Should().Be("");
@@ -90,7 +90,7 @@ public class SplitTests : NCalcTest
 	public void Split_DelimiterAtStart_CreatesEmptyFirst()
 	{
 		var expression = new ExtendedExpression("split(',a,b', ',')");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 		result![0].Should().Be("");
@@ -100,7 +100,7 @@ public class SplitTests : NCalcTest
 	public void Split_DelimiterAtEnd_CreatesEmptyLast()
 	{
 		var expression = new ExtendedExpression("split('a,b,', ',')");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 		result![2].Should().Be("");
@@ -110,7 +110,7 @@ public class SplitTests : NCalcTest
 	public void Split_MultiCharDelimiter_Works()
 	{
 		var expression = new ExtendedExpression("split('one<=>two<=>three', '<=>')");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().BeEquivalentTo(["one", "two", "three"], options => options.WithStrictOrdering());
 	}
@@ -119,7 +119,7 @@ public class SplitTests : NCalcTest
 	public void Split_WithWhitespace_Preserves()
 	{
 		var expression = new ExtendedExpression("split('  a  ,  b  ', ',')");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(2);
 		result![0].Should().Be("  a  ");
@@ -130,7 +130,7 @@ public class SplitTests : NCalcTest
 	public void Split_Newlines_Works()
 	{
 		var expression = new ExtendedExpression("split('line1\nline2\nline3', '\n')");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 	}
@@ -139,7 +139,7 @@ public class SplitTests : NCalcTest
 	public void Split_Tabs_Works()
 	{
 		var expression = new ExtendedExpression("split('col1\tcol2\tcol3', '\t')");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 	}
@@ -148,7 +148,7 @@ public class SplitTests : NCalcTest
 	public void Split_SpecialCharacters_Works()
 	{
 		var expression = new ExtendedExpression("split('a@b#c$d', '@#$')");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		// Split by string '@#$' not by chars
 		result.Should().HaveCount(1);
@@ -160,7 +160,7 @@ public class SplitTests : NCalcTest
 		var expression = new ExtendedExpression("split(myString, myDelimiter)");
 		expression.Parameters["myString"] = "apple;banana;cherry";
 		expression.Parameters["myDelimiter"] = ";";
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().BeEquivalentTo(["apple", "banana", "cherry"], options => options.WithStrictOrdering());
 	}
@@ -169,7 +169,7 @@ public class SplitTests : NCalcTest
 	public void Split_LongString_Works()
 	{
 		var expression = new ExtendedExpression("split('1,2,3,4,5,6,7,8,9,10', ',')");
-		var result = expression.Evaluate() as List<string>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<string>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(10);
 	}
@@ -178,21 +178,21 @@ public class SplitTests : NCalcTest
 	public void Split_ThenJoin_RoundTrip()
 	{
 		var expression = new ExtendedExpression("join(split('a,b,c', ','), ',')");
-		expression.Evaluate().Should().Be("a,b,c");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("a,b,c");
 	}
 
 	[Fact]
 	public void Split_ThenCount_Works()
 	{
 		var expression = new ExtendedExpression("count(split('one two three four', ' '))");
-		expression.Evaluate().Should().Be(4);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(4);
 	}
 
 	[Fact]
 	public void Split_InSelect_Works()
 	{
 		var expression = new ExtendedExpression("select(split('a,b,c', ','), 's', 'toUpper(s)')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().BeEquivalentTo(["A", "B", "C"], options => options.WithStrictOrdering());
 	}
@@ -202,7 +202,7 @@ public class SplitTests : NCalcTest
 	public void Split_NullString_ThrowsException()
 	{
 		var expression = new ExtendedExpression("split(null, ',')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>();
 	}
 
@@ -210,7 +210,7 @@ public class SplitTests : NCalcTest
 	public void Split_NullDelimiter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("split('a,b,c', null)");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>();
 	}
 
@@ -218,7 +218,7 @@ public class SplitTests : NCalcTest
 	public void Split_NonStringFirst_ThrowsException()
 	{
 		var expression = new ExtendedExpression("split(123, ',')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>();
 	}
 
@@ -226,7 +226,7 @@ public class SplitTests : NCalcTest
 	public void Split_NonStringSecond_ThrowsException()
 	{
 		var expression = new ExtendedExpression("split('a,b,c', 123)");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>();
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/StartsWithTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/StartsWithTests.cs
@@ -19,7 +19,7 @@ public class StartsWithTests
 	public void StartsWith_VariousInputs_ReturnsExpected(string text, string prefix, bool expected)
 	{
 		var expression = new ExtendedExpression($"startsWith('{text}','{prefix}')");
-		expression.Evaluate().Should().Be(expected);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(expected);
 	}
 
 	[Theory]
@@ -30,7 +30,7 @@ public class StartsWithTests
 	[InlineData("startsWith('test', null)")]
 	public void StartsWith_InvalidInput_ThrowsException(string expressionText)
 		=> new ExtendedExpression(expressionText)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>();
 
@@ -39,6 +39,6 @@ public class StartsWithTests
 	{
 		var expression = new ExtendedExpression("startsWith(text, 'Hello')");
 		expression.Parameters["text"] = "Hello World";
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/StoreAndRetrieveTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/StoreAndRetrieveTests.cs
@@ -17,7 +17,7 @@ public class StoreAndRetrieveTests
 			: value;
 		var expression = $"convert(store('x', {insertedString}), retrieve('x'))";
 		new ExtendedExpression(expression)
-			.Evaluate()
+			.Evaluate(TestContext.Current.CancellationToken)
 			.Should()
 			.Be(value);
 	}
@@ -37,7 +37,7 @@ public class StoreAndRetrieveTests
 			: value;
 		var expression = $"store('x', {insertedString}) && retrieve('x') == {insertedString}";
 		var result = new ExtendedExpression(expression)
-			.Evaluate();
+			.Evaluate(TestContext.Current.CancellationToken);
 
 		result.Should().Be(true);
 	}
@@ -49,7 +49,7 @@ public class StoreAndRetrieveTests
 	[InlineData("1, 1, 1, 1")]
 	public void Store_IncorrectParameterCount_Throws(string parameters) =>
 		new ExtendedExpression($"store({parameters})")
-		.Invoking(e => e.Evaluate())
+		.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 		.Should()
 		.Throw<FormatException>()
 		.WithMessage($"{ExtensionFunction.Store}() requires two parameters.");
@@ -61,7 +61,7 @@ public class StoreAndRetrieveTests
 	[InlineData("1, 1, 1, 1")]
 	public void Retrieve_IncorrectParameterCount_Throws(string parameters) =>
 		new ExtendedExpression($"retrieve({parameters})")
-		.Invoking(e => e.Evaluate())
+		.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 		.Should()
 		.Throw<FormatException>()
 		.WithMessage($"{ExtensionFunction.Retrieve}() requires one string parameter.");

--- a/PanoramicData.NCalcExtensions.Test/StringTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/StringTests.cs
@@ -16,7 +16,7 @@ public class StringTests
 	{
 		var extendedExpression = new ExtendedExpression(expressionString);
 		extendedExpression.Parameters["x"] = x;
-		var result = extendedExpression.Evaluate();
+		var result = extendedExpression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType(type);
 		result.Should().BeEquivalentTo(expectedOutput);
 	}
@@ -28,7 +28,7 @@ public class StringTests
 	{
 		var expression = new ExtendedExpression(expressionString);
 		expression.Parameters["x"] = x;
-		((Action)(() => expression.Evaluate()))
+		((Action)(() => expression.Evaluate(TestContext.Current.CancellationToken)))
 			.Should()
 			.Throw<FormatException>();
 	}

--- a/PanoramicData.NCalcExtensions.Test/SubstringTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/SubstringTests.cs
@@ -11,35 +11,35 @@ public class SubstringTests
 	public void Substring_HelpExamples_Succeed(string expressionText, string expected)
 	{
 		var expression = new ExtendedExpression(expressionText);
-		(expression.Evaluate() as string).Should().Be(expected);
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be(expected);
 	}
 
 	[Fact]
 	public void Substring_TwoParameters_Succeeds()
 	{
 		var expression = new ExtendedExpression("substring('ABC', 1)");
-		(expression.Evaluate() as string).Should().Be("BC");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("BC");
 	}
 
 	[Fact]
 	public void Substring_ThreeParameters_Succeeds()
 	{
 		var expression = new ExtendedExpression("substring('ABC', 1, 1)");
-		(expression.Evaluate() as string).Should().Be("B");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("B");
 	}
 
 	[Fact]
 	public void Substring_ThreeParametersTruncate_Succeeds()
 	{
 		var expression = new ExtendedExpression("substring('ABC', 0, 6)");
-		(expression.Evaluate() as string).Should().Be("ABC");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("ABC");
 	}
 
 	[Fact]
 	public void Substring_ThreeParametersTruncateMidString_Succeeds()
 	{
 		var expression = new ExtendedExpression("substring('ABC', 1, 6)");
-		(expression.Evaluate() as string).Should().Be("BC");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("BC");
 	}
 
 	// Additional comprehensive tests
@@ -48,42 +48,42 @@ public class SubstringTests
 	public void Substring_EmptyString_ReturnsEmpty()
 	{
 		var expression = new ExtendedExpression("substring('', 0)");
-		(expression.Evaluate() as string).Should().Be("");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("");
 	}
 
 	[Fact]
 	public void Substring_StartAtEnd_ReturnsEmpty()
 	{
 		var expression = new ExtendedExpression("substring('test', 4)");
-		(expression.Evaluate() as string).Should().Be("");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("");
 	}
 
 	[Fact]
 	public void Substring_LengthZero_ReturnsEmpty()
 	{
 		var expression = new ExtendedExpression("substring('test', 1, 0)");
-		(expression.Evaluate() as string).Should().Be("");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("");
 	}
 
 	[Fact]
 	public void Substring_SingleCharacter_ReturnsChar()
 	{
 		var expression = new ExtendedExpression("substring('A', 0, 1)");
-		(expression.Evaluate() as string).Should().Be("A");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("A");
 	}
 
 	[Fact]
 	public void Substring_LastCharacter_ReturnsChar()
 	{
 		var expression = new ExtendedExpression("substring('ABC', 2, 1)");
-		(expression.Evaluate() as string).Should().Be("C");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("C");
 	}
 
 	[Fact]
 	public void Substring_MiddleSection_ReturnsSection()
 	{
 		var expression = new ExtendedExpression("substring('ABCDEF', 2, 2)");
-		(expression.Evaluate() as string).Should().Be("CD");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("CD");
 	}
 
 	[Theory]
@@ -91,7 +91,7 @@ public class SubstringTests
 	[InlineData("substring('test')")]
 	public void Substring_WrongParameterCount_ThrowsException(string expressionText)
 		=> new ExtendedExpression(expressionText)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>();
 
@@ -100,41 +100,41 @@ public class SubstringTests
 	{
 		// Substring accepts 2 or 3 parameters, extra ones are ignored
 		var expression = new ExtendedExpression("substring('test', 0, 2, 999)");
-		(expression.Evaluate() as string).Should().Be("te");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("te");
 	}
 
 	[Fact]
 	public void Substring_NullString_ThrowsException()
 		=> new ExtendedExpression("substring(null, 0)")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>();
 
 	[Fact]
 	public void Substring_NegativeStart_ThrowsException()
 		=> new ExtendedExpression("substring('test', -1)")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>();
 
 	[Fact]
 	public void Substring_NegativeLength_ThrowsException()
 		=> new ExtendedExpression("substring('test', 0, -1)")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>();
 
 	[Fact]
 	public void Substring_StartBeyondLength_ThrowsException()
 		=> new ExtendedExpression("substring('test', 10)")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>();
 
 	[Fact]
 	public void Substring_NonIntegerStartIndex_ThrowsException()
 		=> new ExtendedExpression("substring('test', 'abc')")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*one or two numeric parameters*");
@@ -142,7 +142,7 @@ public class SubstringTests
 	[Fact]
 	public void Substring_NonIntegerLength_ThrowsException()
 		=> new ExtendedExpression("substring('test', 0, 'abc')")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.Throw<FormatException>()
 			.WithMessage("*one or two numeric parameters*");
@@ -151,13 +151,13 @@ public class SubstringTests
 	public void Substring_WithSpaces_HandlesCorrectly()
 	{
 		var expression = new ExtendedExpression("substring('hello world', 6, 5)");
-		(expression.Evaluate() as string).Should().Be("world");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("world");
 	}
 
 	[Fact]
 	public void Substring_WholeString_ReturnsWholeString()
 	{
 		var expression = new ExtendedExpression("substring('complete', 0)");
-		(expression.Evaluate() as string).Should().Be("complete");
+		(expression.Evaluate(TestContext.Current.CancellationToken) as string).Should().Be("complete");
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/SumTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/SumTests.cs
@@ -14,7 +14,7 @@ public class SumTests
 	{
 		var expression = new ExtendedExpression($"sum(x, 'n', 'n * n')");
 		expression.Parameters.Add("x", _intList);
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(_intList.Sum(n => n * n));
 	}
 
@@ -23,7 +23,7 @@ public class SumTests
 	{
 		var expression = new ExtendedExpression($"sum(list(100, 100, 100), 'n', 'n')");
 		expression.Parameters.Add("x", _intList);
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(300);
 	}
 
@@ -32,7 +32,7 @@ public class SumTests
 	{
 		var expression = new ExtendedExpression($"sum(x)");
 		expression.Parameters.Add("x", _intList.AsEnumerable());
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(_intList.Sum());
 	}
 
@@ -41,7 +41,7 @@ public class SumTests
 	{
 		var expression = new ExtendedExpression($"sum(x)");
 		expression.Parameters.Add("x", _intList);
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(_intList.Sum());
 	}
 
@@ -50,7 +50,7 @@ public class SumTests
 	{
 		var expression = new ExtendedExpression($"sum(x)");
 		expression.Parameters.Add("x", _objectList);
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(_intList.Sum());
 	}
 
@@ -60,7 +60,7 @@ public class SumTests
 	public void Sum_EmptyList_ReturnsZero()
 	{
 		var expression = new ExtendedExpression("sum(list())");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(0d);
 	}
 
@@ -68,7 +68,7 @@ public class SumTests
 	public void Sum_AllZeros_ReturnsZero()
 	{
 		var expression = new ExtendedExpression("sum(list(0, 0, 0, 0))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(0);
 	}
 
@@ -76,7 +76,7 @@ public class SumTests
 	public void Sum_NegativeNumbers_ReturnsNegativeSum()
 	{
 		var expression = new ExtendedExpression("sum(list(-1, -2, -3))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(-6);
 	}
 
@@ -84,7 +84,7 @@ public class SumTests
 	public void Sum_MixedPositiveAndNegative_ReturnsCorrectSum()
 	{
 		var expression = new ExtendedExpression("sum(list(10, -5, 3, -2))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(6);
 	}
 
@@ -92,7 +92,7 @@ public class SumTests
 	public void Sum_VeryLargeNumbers_HandlesOverflow()
 	{
 		var expression = new ExtendedExpression("sum(list(1000000000, 1000000000, 1000000000))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(3000000000);
 	}
 
@@ -100,7 +100,7 @@ public class SumTests
 	public void Sum_Decimals_RetainsDecimalPrecision()
 	{
 		var expression = new ExtendedExpression("sum(list(1.5, 2.5, 3.5))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(7.5);
 	}
 
@@ -108,7 +108,7 @@ public class SumTests
 	public void Sum_ByteValues_ConvertsCorrectly()
 	{
 		var expression = new ExtendedExpression("sum(listOf('byte', 1, 2, 3))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(6);
 	}
 
@@ -116,7 +116,7 @@ public class SumTests
 	public void Sum_ShortValues_ConvertsCorrectly()
 	{
 		var expression = new ExtendedExpression("sum(listOf('short', 100, 200, 300))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(600);
 	}
 
@@ -124,7 +124,7 @@ public class SumTests
 	public void Sum_LongValues_ConvertsCorrectly()
 	{
 		var expression = new ExtendedExpression("sum(listOf('long', 1000, 2000, 3000))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(6000L);
 	}
 
@@ -132,7 +132,7 @@ public class SumTests
 	public void Sum_FloatValues_HandlesFloatingPoint()
 	{
 		var expression = new ExtendedExpression("sum(listOf('float', 1.1, 2.2, 3.3))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		((float)result!).Should().BeApproximately(6.6f, 0.01f);
 	}
 
@@ -140,7 +140,7 @@ public class SumTests
 	public void Sum_DoubleValues_HandlesFloatingPoint()
 	{
 		var expression = new ExtendedExpression("sum(listOf('double', 1.1, 2.2, 3.3))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		((double)result!).Should().BeApproximately(6.6, 0.01);
 	}
 
@@ -148,7 +148,7 @@ public class SumTests
 	public void Sum_WithLambdaOnEmptyList_ReturnsZero()
 	{
 		var expression = new ExtendedExpression("sum(list(), 'x', 'x * 2')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(0d);
 	}
 
@@ -156,7 +156,7 @@ public class SumTests
 	public void Sum_SingleItem_ReturnsThatItem()
 	{
 		var expression = new ExtendedExpression("sum(list(42))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(42);
 	}
 
@@ -165,7 +165,7 @@ public class SumTests
 	public void Sum_ByteWithLambda_ReturnsCorrectSum()
 	{
 		var expression = new ExtendedExpression("sum(listOf('byte', 1, 2, 3), 'n', 'n * 2')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(12);
 	}
 
@@ -173,7 +173,7 @@ public class SumTests
 	public void Sum_ShortWithLambda_ReturnsCorrectSum()
 	{
 		var expression = new ExtendedExpression("sum(listOf('short', 10, 20, 30), 'n', 'n * 2')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(120);
 	}
 
@@ -181,7 +181,7 @@ public class SumTests
 	public void Sum_LongWithLambda_ReturnsCorrectSum()
 	{
 		var expression = new ExtendedExpression("sum(listOf('long', 100, 200, 300), 'n', 'n * 2')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(1200L);
 	}
 
@@ -189,7 +189,7 @@ public class SumTests
 	public void Sum_FloatWithLambda_ReturnsCorrectSum()
 	{
 		var expression = new ExtendedExpression("sum(listOf('float', 1.0, 2.0, 3.0), 'n', 'n * 2')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		((float)result!).Should().BeApproximately(12.0f, 0.01f);
 	}
 
@@ -197,7 +197,7 @@ public class SumTests
 	public void Sum_DoubleWithLambda_ReturnsCorrectSum()
 	{
 		var expression = new ExtendedExpression("sum(listOf('double', 1.0, 2.0, 3.0), 'n', 'n * 2')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		((double)result!).Should().BeApproximately(12.0, 0.01);
 	}
 
@@ -205,7 +205,7 @@ public class SumTests
 	public void Sum_DecimalWithLambda_ReturnsCorrectSum()
 	{
 		var expression = new ExtendedExpression("sum(listOf('decimal', 1.5, 2.5, 3.5), 'n', 'n * 2')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(15.0m);
 	}
 
@@ -214,7 +214,7 @@ public class SumTests
 	public void Sum_JValueInteger_ReturnsCorrectSum()
 	{
 		var expression = new ExtendedExpression("sum(jArray(1, 2, 3))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(6.0);
 	}
 
@@ -222,7 +222,7 @@ public class SumTests
 	public void Sum_JValueFloat_ReturnsCorrectSum()
 	{
 		var expression = new ExtendedExpression("sum(jArray(1.5, 2.5, 3.0))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		((double)result!).Should().BeApproximately(7.0, 0.01);
 	}
 
@@ -231,7 +231,7 @@ public class SumTests
 	public void Sum_NullParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("sum(null)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*cannot be null*");
 	}
 
@@ -239,7 +239,7 @@ public class SumTests
 	public void Sum_InvalidSecondParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("sum(list(1, 2, 3), 123, 'n')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*must be a string*");
 	}
 
@@ -247,7 +247,7 @@ public class SumTests
 	public void Sum_InvalidThirdParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("sum(list(1, 2, 3), 'n', 456)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*must be a string*");
 	}
 
@@ -255,7 +255,7 @@ public class SumTests
 	public void Sum_UnsupportedTypeWithoutLambda_ThrowsException()
 	{
 		var expression = new ExtendedExpression("sum(list('a', 'b', 'c'))");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>();
 	}
 
 	[Fact]
@@ -263,7 +263,7 @@ public class SumTests
 	{
 		var expression = new ExtendedExpression("sum(TheList)");
 		expression.Parameters["TheList"] = new List<object?> { 1, 2, "invalid" };
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*unsupported type*");
 	}
 
@@ -274,7 +274,7 @@ public class SumTests
 	{
 		var expression = new ExtendedExpression("sum(jValueList)");
 		expression.Parameters["jValueList"] = new List<object?> { new JValue(true), new JValue(false) };
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*Found unsupported JToken type*");
 	}
 
@@ -283,7 +283,7 @@ public class SumTests
 	{
 		var expression = new ExtendedExpression("sum(stringList, 'x', 'x')");
 		expression.Parameters["stringList"] = new List<string> { "a", "b", "c" };
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*Found unsupported type*when completing sum*");
 	}
 
@@ -292,7 +292,7 @@ public class SumTests
 	{
 		var expression = new ExtendedExpression("sum(stringList)");
 		expression.Parameters["stringList"] = new List<string> { "a", "b", "c" };
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*Found unsupported type*when completing sum*");
 	}
 
@@ -301,7 +301,7 @@ public class SumTests
 	{
 		var expression = new ExtendedExpression("sum(mixedList)");
 		expression.Parameters["mixedList"] = new List<object?> { 1, null, 2, null, 3 };
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(6.0);
 	}
 
@@ -309,7 +309,7 @@ public class SumTests
 	public void Sum_DecimalList_ReturnsDecimalSum()
 	{
 		var expression = new ExtendedExpression("sum(listOf('decimal', 1.5, 2.5, 3.5))");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(7.5m);
 	}
 
@@ -318,7 +318,7 @@ public class SumTests
 	{
 		var expression = new ExtendedExpression("sum(mixedList, 'x', 'x * 2')");
 		expression.Parameters["mixedList"] = new List<object?> { 1, 2, 3 };
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(12.0);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/SwitchTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/SwitchTests.cs
@@ -8,7 +8,7 @@ public class SwitchTests : NCalcTest
 	[InlineData("switch(1, 2)")]
 	public void Switch_InsufficientParameters_ThrowsException(string expression)
 		=> new ExtendedExpression(expression)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<FormatException>();
 
@@ -22,13 +22,13 @@ public class SwitchTests : NCalcTest
 	[InlineData("switch('blah', 'yes', 1, 'no', 2, '3')", "3")]
 	[InlineData("switch(1, 1, 'one', 2, 'two')", "one")]
 	public void Switch_ReturnsExpected(string expression, object expectedOutput)
-		=> new ExtendedExpression(expression).Evaluate().Should().Be(expectedOutput);
+		=> new ExtendedExpression(expression).Evaluate(TestContext.Current.CancellationToken).Should().Be(expectedOutput);
 
 	[Theory]
 	[InlineData("switch('blah', 'yes', 1, 'no', 2)")]
 	public void Switch_MissingDefault_ThrowsException(string expression)
 		=> new ExtendedExpression(expression)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<FormatException>();
 
@@ -38,7 +38,7 @@ public class SwitchTests : NCalcTest
 		const string expression = "switch(incident_Priority, 4, 4, 1, 1, 21)";
 		var e = new ExtendedExpression(expression);
 		e.Parameters["incident_Priority"] = 1;
-		var result = e.Evaluate();
+		var result = e.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(1);
 	}
 
@@ -49,7 +49,7 @@ public class SwitchTests : NCalcTest
 		var e = new ExtendedExpression(expression);
 		e.Parameters["incident_exists"] = true;
 		e.Parameters["incident_Priority"] = 4;
-		var result = e.Evaluate();
+		var result = e.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(4);
 	}
 
@@ -69,7 +69,7 @@ public class SwitchTests : NCalcTest
 			e.Parameters[property.Name] = GetValue(property);
 		}
 
-		var result = e.Evaluate();
+		var result = e.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(4);
 	}
 

--- a/PanoramicData.NCalcExtensions.Test/TakeTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/TakeTests.cs
@@ -7,7 +7,7 @@ public class TakeTests
 	public void List_OfInts_ReturnsExpectedType()
 	{
 		var expression = new ExtendedExpression($"take(list(1, 2, 3), 1)");
-		expression.Evaluate().Should().BeOfType<List<object?>>();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeOfType<List<object?>>();
 	}
 
 	[Fact]
@@ -15,7 +15,7 @@ public class TakeTests
 	{
 		var expression = new ExtendedExpression($"take(theArray, 1)");
 		expression.Parameters["theArray"] = new[] { 1, 2, 3 };
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<List<object?>>();
 		result.Should().BeEquivalentTo(new[] { 1 });
 	}
@@ -24,20 +24,20 @@ public class TakeTests
 	public void List_OfInts_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression($"take(list('a', 2, 3), 1)");
-		expression.Evaluate().Should().BeEquivalentTo(new List<object> { "a" }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<object> { "a" }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void TakingTooMany_ReturnsExpected()
 	{
 		var expression = new ExtendedExpression($"take(list(1, 2, 3), 10)");
-		expression.Evaluate().Should().BeEquivalentTo(new List<object> { 1, 2, 3 }, options => options.WithStrictOrdering());
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeEquivalentTo(new List<object> { 1, 2, 3 }, options => options.WithStrictOrdering());
 	}
 
 	[Fact]
 	public void Take_InvalidCountParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("take(list(1, 2, 3), 'invalid')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>();
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/ThrowTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/ThrowTests.cs
@@ -6,34 +6,34 @@ public class ThrowTests
 	public void Throw_Example1_Succeeds()
 	{
 		var expression = new ExtendedExpression("throw()");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<NCalcExtensionsException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<NCalcExtensionsException>();
 	}
 
 	[Fact]
 	public void Throw_Example2_Succeeds()
 	{
 		var expression = new ExtendedExpression("throw('This is a message')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<NCalcExtensionsException>();
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<NCalcExtensionsException>();
 	}
 
 	[Fact]
 	public void Throw_Example3_Succeeds()
 		=> new ExtendedExpression("if(true, throw('There is a problem'), 5)")
-		.Invoking(e => e.Evaluate())
+		.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 		.Should()
 		.ThrowExactly<NCalcExtensionsException>();
 
 	[Fact]
 	public void Throw_BadParameter_Fails()
 		=> new ExtendedExpression("throw(666)")
-		.Invoking(e => e.Evaluate())
+		.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 		.Should()
 		.ThrowExactly<FormatException>();
 
 	[Fact]
 	public void Throw_TooManyParameters_Fails()
 		=> new ExtendedExpression("throw('a', 'b')")
-		.Invoking(e => e.Evaluate())
+		.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 		.Should()
 		.ThrowExactly<FormatException>();
 
@@ -43,7 +43,7 @@ public class ThrowTests
 		var expression = new ExtendedExpression("if(false, 1, throw('sdf' + a))");
 		expression.Parameters["a"] = "blah";
 		expression
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<NCalcExtensionsException>();
 	}

--- a/PanoramicData.NCalcExtensions.Test/TimeSpanTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/TimeSpanTests.cs
@@ -43,7 +43,7 @@ public class TimeSpanTests : NCalcTest
 		var expression = new ExtendedExpression("timespan(start, end, 'Hours')");
 		expression.Parameters["start"] = "2020-01-01 00:00";
 		expression.Parameters["end"] = "2020-01-01 12:00";
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(12.0);
 	}
 
@@ -61,7 +61,7 @@ public class TimeSpanTests : NCalcTest
 		var expression = new ExtendedExpression("timespan(dt1, dt2, 'Days')");
 		expression.Parameters["dt1"] = new DateTime(2020, 1, 1);
 		expression.Parameters["dt2"] = new DateTime(2020, 1, 10);
-		expression.Evaluate().Should().Be(9.0);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(9.0);
 	}
 
 	[Theory]
@@ -96,6 +96,6 @@ public class TimeSpanTests : NCalcTest
 	[InlineData("timespan('not a date', '2020-01-01', 'Days')")]
 	[InlineData("timespan('2020-01-01', '2020-01-02', 'InvalidFormat')")]
 	public void TimeSpan_InvalidInput_ThrowsException(string expression) => new ExtendedExpression(expression)
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<Exception>();
 }

--- a/PanoramicData.NCalcExtensions.Test/ToDateTimeTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/ToDateTimeTests.cs
@@ -17,7 +17,7 @@ public class ToDateTimeTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("toDateTime('2020-02-29 12:00')");
 		AssertionExtensions
-			.Should(() => { expression.Evaluate(); })
+			.Should(() => { expression.Evaluate(TestContext.Current.CancellationToken); })
 			.Throw<ArgumentException>();
 	}
 
@@ -51,7 +51,7 @@ public class ToDateTimeTests : NCalcTest
 		var estDateTime = new DateTime(2020, 03, 02, 12, 00, 00);
 		var expression = new ExtendedExpression("toDateTime(estDateTime, 'Eastern Standard Time')");
 		expression.Parameters[nameof(estDateTime)] = estDateTime;
-		var utcDateTime = expression.Evaluate();
+		var utcDateTime = expression.Evaluate(TestContext.Current.CancellationToken);
 		utcDateTime.Should().Be(new DateTime(2020, 03, 02, 17, 00, 00));
 	}
 
@@ -61,7 +61,7 @@ public class ToDateTimeTests : NCalcTest
 		object? estDateTime = null;
 		var expression = new ExtendedExpression("toDateTime(estDateTime, 'Eastern Standard Time')");
 		expression.Parameters[nameof(estDateTime)] = estDateTime;
-		var utcDateTime = expression.Evaluate();
+		var utcDateTime = expression.Evaluate(TestContext.Current.CancellationToken);
 		utcDateTime.Should().BeNull();
 	}
 
@@ -72,7 +72,7 @@ public class ToDateTimeTests : NCalcTest
 		var expression = new ExtendedExpression("toDateTime(theDateTime)");
 		expression.Parameters[nameof(estDateTime)] = estDateTime;
 		AssertionExtensions
-			.Should(() => { expression.Evaluate(); })
+			.Should(() => { expression.Evaluate(TestContext.Current.CancellationToken); })
 			// Change in NCalc 5.6.0 - was ArgumentException
 			.Throw<NCalcParameterNotDefinedException>();
 	}
@@ -83,7 +83,7 @@ public class ToDateTimeTests : NCalcTest
 		var expectedDateTime = new DateTime(1975, 02, 17, 00, 00, 00);
 		var expression = new ExtendedExpression("toDateTime(161827200.0, 's', 'UTC')");
 		expression.Parameters[nameof(expectedDateTime)] = expectedDateTime;
-		expression.Evaluate().Should().Be(expectedDateTime);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(expectedDateTime);
 	}
 
 	[Fact]
@@ -92,7 +92,7 @@ public class ToDateTimeTests : NCalcTest
 		var expectedDateTime = new DateTime(1975, 02, 17, 00, 00, 00);
 		var expression = new ExtendedExpression("toDateTime(161827200000.0, 'ms', 'UTC')");
 		expression.Parameters[nameof(expectedDateTime)] = expectedDateTime;
-		expression.Evaluate().Should().Be(expectedDateTime);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(expectedDateTime);
 	}
 
 	[Fact]
@@ -101,6 +101,6 @@ public class ToDateTimeTests : NCalcTest
 		var expectedDateTime = new DateTime(1975, 02, 17, 00, 00, 00);
 		var expression = new ExtendedExpression("toDateTime(161827200000000.0, 'us', 'UTC')");
 		expression.Parameters[nameof(expectedDateTime)] = expectedDateTime;
-		expression.Evaluate().Should().Be(expectedDateTime);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(expectedDateTime);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/ToLowerTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/ToLowerTests.cs
@@ -9,7 +9,7 @@ public class ToLowerTests
 	public void ToLower_UsingInlineData_ResultMatchExpectedValue(string parameter, string expectedValue)
 	{
 		var expression = new ExtendedExpression($"toLower('{parameter}')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(expectedValue);
 	}
 
@@ -17,7 +17,7 @@ public class ToLowerTests
 	public void ToLower_NullParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("toLower(null)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*requires one string parameter*");
 	}
 
@@ -25,7 +25,7 @@ public class ToLowerTests
 	public void ToLower_NonStringParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("toLower(123)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*requires one string parameter*");
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/ToStringTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/ToStringTests.cs
@@ -6,21 +6,21 @@ public class ToStringTests
 	public void ToString_IsNull_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("toString(null)");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
 	public void ToString_Int_Succeeds()
 	{
 		var expression = new ExtendedExpression("toString(1)");
-		expression.Evaluate().Should().Be("1");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("1");
 	}
 
 	[Fact]
 	public void ToString_Int_Formatted_Succeeds()
 	{
 		var expression = new ExtendedExpression("toString(1000, 'N2')");
-		expression.Evaluate().Should().Be("1,000.00");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("1,000.00");
 	}
 
 	[Fact]
@@ -28,7 +28,7 @@ public class ToStringTests
 	{
 		var expression = new ExtendedExpression("toString(TheDateTime, 'yyyy-MM-dd')");
 		expression.Parameters.Add("TheDateTime", new DateTime(2020, 1, 1));
-		expression.Evaluate().Should().Be("2020-01-01");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("2020-01-01");
 	}
 
 	[Fact]
@@ -36,7 +36,7 @@ public class ToStringTests
 	{
 		var expression = new ExtendedExpression("toString(TheDateTimeOffset, 'yyyy-MM-dd')");
 		expression.Parameters.Add("TheDateTimeOffset", new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero));
-		expression.Evaluate().Should().Be("2020-01-01");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("2020-01-01");
 	}
 
 	// Additional format specifier tests
@@ -44,7 +44,7 @@ public class ToStringTests
 	public void ToString_Currency_Format_Succeeds()
 	{
 		var expression = new ExtendedExpression("toString(1234.56, 'C2')");
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().Contain("1,234.56"); // Format varies by culture but should contain these digits
 	}
 
@@ -52,7 +52,7 @@ public class ToStringTests
 	public void ToString_Percent_Format_Succeeds()
 	{
 		var expression = new ExtendedExpression("toString(0.1234, 'P2')");
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().Contain("12.34"); // Should show as percentage
 	}
 
@@ -60,7 +60,7 @@ public class ToStringTests
 	public void ToString_Exponential_Format_Succeeds()
 	{
 		var expression = new ExtendedExpression("toString(1234.56, 'E2')");
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().MatchRegex(@"1\.23[Ee][+]0*3"); // Exponential notation - allow extra zeros
 	}
 
@@ -68,14 +68,14 @@ public class ToStringTests
 	public void ToString_FixedPoint_Format_Succeeds()
 	{
 		var expression = new ExtendedExpression("toString(1234.567, 'F2')");
-		expression.Evaluate().Should().Be("1234.57");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("1234.57");
 	}
 
 	[Fact]
 	public void ToString_General_Format_Succeeds()
 	{
 		var expression = new ExtendedExpression("toString(1234.567, 'G')");
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().NotBeNullOrEmpty();
 	}
 
@@ -83,42 +83,42 @@ public class ToStringTests
 	public void ToString_Hexadecimal_Format_Succeeds()
 	{
 		var expression = new ExtendedExpression("toString(255, 'X')");
-		expression.Evaluate().Should().Be("FF");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("FF");
 	}
 
 	[Fact]
 	public void ToString_HexadecimalLowercase_Format_Succeeds()
 	{
 		var expression = new ExtendedExpression("toString(255, 'x')");
-		expression.Evaluate().Should().Be("ff");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("ff");
 	}
 
 	[Fact]
 	public void ToString_Double_NoFormat_Succeeds()
 	{
 		var expression = new ExtendedExpression("toString(123.456)");
-		expression.Evaluate().Should().Be("123.456");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("123.456");
 	}
 
 	[Fact]
 	public void ToString_String_NoFormat_ReturnsString()
 	{
 		var expression = new ExtendedExpression("toString('hello')");
-		expression.Evaluate().Should().Be("hello");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("hello");
 	}
 
 	[Fact]
 	public void ToString_Boolean_True_ReturnsTrue()
 	{
 		var expression = new ExtendedExpression("toString(true)");
-		expression.Evaluate().Should().Be("True");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("True");
 	}
 
 	[Fact]
 	public void ToString_Boolean_False_ReturnsFalse()
 	{
 		var expression = new ExtendedExpression("toString(false)");
-		expression.Evaluate().Should().Be("False");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("False");
 	}
 
 	[Fact]
@@ -126,7 +126,7 @@ public class ToStringTests
 	{
 		var expression = new ExtendedExpression("toString(TheDateTime, 'MM/dd/yyyy HH:mm:ss')");
 		expression.Parameters.Add("TheDateTime", new DateTime(2020, 3, 15, 14, 30, 45));
-		expression.Evaluate().Should().Be("03/15/2020 14:30:45");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("03/15/2020 14:30:45");
 	}
 
 	[Fact]
@@ -134,7 +134,7 @@ public class ToStringTests
 	{
 		var expression = new ExtendedExpression("toString(TheDateTime, 'd')");
 		expression.Parameters.Add("TheDateTime", new DateTime(2020, 1, 1));
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().NotBeNullOrEmpty(); // Culture-specific
 	}
 
@@ -143,7 +143,7 @@ public class ToStringTests
 	{
 		var expression = new ExtendedExpression("toString(TheDateTime, 'D')");
 		expression.Parameters.Add("TheDateTime", new DateTime(2020, 1, 1));
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().NotBeNullOrEmpty(); // Culture-specific
 	}
 
@@ -153,7 +153,7 @@ public class ToStringTests
 		// Note: tostring doesn't format decimal currently, it falls through to object.ToString()
 		var expression = new ExtendedExpression("toString(TheDecimal)");
 		expression.Parameters.Add("TheDecimal", 1234.5678m);
-		expression.Evaluate().Should().Be("1234.5678");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("1234.5678");
 	}
 
 	[Fact]
@@ -161,7 +161,7 @@ public class ToStringTests
 	{
 		var expression = new ExtendedExpression("toString(TheLong)");
 		expression.Parameters.Add("TheLong", 9223372036854775807L);
-		expression.Evaluate().Should().Be("9223372036854775807");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("9223372036854775807");
 	}
 
 	[Fact]
@@ -169,7 +169,7 @@ public class ToStringTests
 	{
 		var expression = new ExtendedExpression("toString(TheFloat)");
 		expression.Parameters.Add("TheFloat", 123.45f);
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().StartWith("123.45");
 	}
 
@@ -177,14 +177,14 @@ public class ToStringTests
 	public void ToString_ZeroPadding_Format_Succeeds()
 	{
 		var expression = new ExtendedExpression("toString(42, '0000')");
-		expression.Evaluate().Should().Be("0042");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("0042");
 	}
 
 	[Fact]
 	public void ToString_CustomNumeric_Format_Succeeds()
 	{
 		var expression = new ExtendedExpression("toString(1234.567, '#,##0.00')");
-		expression.Evaluate().Should().Be("1,234.57");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("1,234.57");
 	}
 
 	// Tests for all numeric types with format parameter
@@ -193,7 +193,7 @@ public class ToStringTests
 	{
 		var expression = new ExtendedExpression("toString(TheByte, 'X2')");
 		expression.Parameters.Add("TheByte", (byte)255);
-		expression.Evaluate().Should().Be("FF");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("FF");
 	}
 
 	[Fact]
@@ -201,7 +201,7 @@ public class ToStringTests
 	{
 		var expression = new ExtendedExpression("toString(TheUInt, 'N0')");
 		expression.Parameters.Add("TheUInt", 1000u);
-		expression.Evaluate().Should().Be("1,000");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("1,000");
 	}
 
 	[Fact]
@@ -209,7 +209,7 @@ public class ToStringTests
 	{
 		var expression = new ExtendedExpression("toString(TheLong, 'N0')");
 		expression.Parameters.Add("TheLong", 1000000L);
-		expression.Evaluate().Should().Be("1,000,000");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("1,000,000");
 	}
 
 	[Fact]
@@ -217,7 +217,7 @@ public class ToStringTests
 	{
 		var expression = new ExtendedExpression("toString(TheULong, 'N0')");
 		expression.Parameters.Add("TheULong", 1000000UL);
-		expression.Evaluate().Should().Be("1,000,000");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("1,000,000");
 	}
 
 	[Fact]
@@ -225,7 +225,7 @@ public class ToStringTests
 	{
 		var expression = new ExtendedExpression("toString(TheShort, 'N0')");
 		expression.Parameters.Add("TheShort", (short)1000);
-		expression.Evaluate().Should().Be("1,000");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("1,000");
 	}
 
 	[Fact]
@@ -233,7 +233,7 @@ public class ToStringTests
 	{
 		var expression = new ExtendedExpression("toString(TheUShort, 'N0')");
 		expression.Parameters.Add("TheUShort", (ushort)1000);
-		expression.Evaluate().Should().Be("1,000");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("1,000");
 	}
 
 	[Fact]
@@ -241,7 +241,7 @@ public class ToStringTests
 	{
 		var expression = new ExtendedExpression("toString(TheFloat, 'F2')");
 		expression.Parameters.Add("TheFloat", 123.456f);
-		expression.Evaluate().Should().Be("123.46");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("123.46");
 	}
 
 	[Fact]
@@ -249,7 +249,7 @@ public class ToStringTests
 	{
 		var expression = new ExtendedExpression("toString(TheDouble, 'F2')");
 		expression.Parameters.Add("TheDouble", 123.456);
-		expression.Evaluate().Should().Be("123.46");
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be("123.46");
 	}
 
 	// Error case tests
@@ -257,7 +257,7 @@ public class ToStringTests
 	public void ToString_TooManyParameters_ThrowsException()
 	{
 		var expression = new ExtendedExpression("toString(1, 'N2', 'extra')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*one or two parameters*");
 	}
 
@@ -265,7 +265,7 @@ public class ToStringTests
 	public void ToString_InvalidFormatParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("toString(123, 123)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*string as the second parameter*");
 	}
 
@@ -273,7 +273,7 @@ public class ToStringTests
 	public void ToString_NullWithFormat_ReturnsNull()
 	{
 		var expression = new ExtendedExpression("toString(null, 'N2')");
-		expression.Evaluate().Should().BeNull();
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().BeNull();
 	}
 
 	[Fact]
@@ -281,7 +281,7 @@ public class ToStringTests
 	{
 		var expression = new ExtendedExpression("toString(TheObject, 'anyformat')");
 		expression.Parameters.Add("TheObject", new { Name = "Test" });
-		var result = expression.Evaluate() as string;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as string;
 		result.Should().NotBeNullOrEmpty();
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/ToUpperTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/ToUpperTests.cs
@@ -9,7 +9,7 @@ public class ToUpperTests
 	public void ToUpper_UsingInlineData_ResultMatchExpectedValue(string input, string expected)
 	{
 		var expression = new ExtendedExpression($"toUpper('{input}')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(expected);
 	}
 
@@ -17,7 +17,7 @@ public class ToUpperTests
 	public void ToUpper_NullParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("toUpper(null)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*requires one string parameter*");
 	}
 
@@ -25,7 +25,7 @@ public class ToUpperTests
 	public void ToUpper_NonStringParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("toUpper(123)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*requires one string parameter*");
 	}
 }
@@ -44,7 +44,7 @@ public class TrimTests
 		var input = $"{prefix}test{suffix}";
 		var expression = new ExtendedExpression($"trim(x)");
 		expression.Parameters.Add("x", input);
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be("test");
 	}
 
@@ -52,7 +52,7 @@ public class TrimTests
 	public void Trim_NullParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("trim(null)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*requires one string parameter*");
 	}
 
@@ -60,7 +60,7 @@ public class TrimTests
 	public void Trim_NonStringParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("trim(123)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*requires one string parameter*");
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/TryParseTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/TryParseTests.cs
@@ -11,7 +11,7 @@ public class TryParseTests
 	[InlineData("1")]
 	public void TryParse_IncorrectParameterCountOrType_Throws(string parameters)
 		=> new ExtendedExpression($"tryParse({parameters})")
-			.Invoking(e => e.Evaluate())
+			.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should()
 			.ThrowExactly<FormatException>();
 
@@ -33,7 +33,7 @@ public class TryParseTests
 	public void TryParse_DoesNotParse_ReturnsFalse(string parameters)
 	{
 		var expression = new ExtendedExpression($"tryParse('{parameters}', 'x', 'outputVariable')");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	[Theory]
@@ -44,7 +44,7 @@ public class TryParseTests
 	public void TryParse_Bool_Succeeds(string text)
 	{
 		var expression = new ExtendedExpression($"tryParse('bool', '{text}', 'outputVariable')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -53,91 +53,91 @@ public class TryParseTests
 	public void TryParse_SystemBoolean_Succeeds()
 	{
 		var expression = new ExtendedExpression("tryParse('System.Boolean', 'true', 'outputVariable')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void TryParse_SystemInt32_Succeeds()
 	{
 		var expression = new ExtendedExpression("tryParse('System.Int32', '42', 'outputVariable')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void TryParse_SystemInt64_Succeeds()
 	{
 		var expression = new ExtendedExpression("tryParse('System.Int64', '123456789', 'outputVariable')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void TryParse_SystemUInt32_Succeeds()
 	{
 		var expression = new ExtendedExpression("tryParse('System.UInt32', '42', 'outputVariable')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void TryParse_SystemUInt64_Succeeds()
 	{
 		var expression = new ExtendedExpression("tryParse('System.UInt64', '123456789', 'outputVariable')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void TryParse_SystemDouble_Succeeds()
 	{
 		var expression = new ExtendedExpression("tryParse('System.Double', '3.14', 'outputVariable')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void TryParse_SystemSingle_Succeeds()
 	{
 		var expression = new ExtendedExpression("tryParse('System.Single', '3.14', 'outputVariable')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void TryParse_SystemDecimal_Succeeds()
 	{
 		var expression = new ExtendedExpression("tryParse('System.Decimal', '3.14', 'outputVariable')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void TryParse_SystemByte_Succeeds()
 	{
 		var expression = new ExtendedExpression("tryParse('System.Byte', '255', 'outputVariable')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void TryParse_SystemSByte_Succeeds()
 	{
 		var expression = new ExtendedExpression("tryParse('System.SByte', '-128', 'outputVariable')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void TryParse_SystemInt16_Succeeds()
 	{
 		var expression = new ExtendedExpression("tryParse('System.Int16', '32767', 'outputVariable')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void TryParse_SystemUInt16_Succeeds()
 	{
 		var expression = new ExtendedExpression("tryParse('System.UInt16', '65535', 'outputVariable')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void TryParse_SystemGuid_Succeeds()
 	{
 		var expression = new ExtendedExpression("tryParse('System.Guid', 'fa2e60e8-dd1e-4cbb-b53c-e69c63f14866', 'outputVariable')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Theory]
@@ -149,7 +149,7 @@ public class TryParseTests
 	{
 		var expectedValue = int.TryParse(text, out var expected) ? expected : (int?)null;
 		var expression = new ExtendedExpression($"if(tryParse('int', '{text}', 'outputVariable'), retrieve('outputVariable'), null)");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().NotBe(null);
 		result.Should().Be(expectedValue);
 	}
@@ -165,7 +165,7 @@ public class TryParseTests
 	{
 		var expectedValue = Guid.TryParse(text, out var expected) ? expected : (Guid?)null;
 		var expression = new ExtendedExpression($"if(tryParse('Guid', '{text}', 'outputVariable'), retrieve('outputVariable'), null)");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().NotBe(null);
 		result.Should().Be(expectedValue);
 	}
@@ -178,7 +178,7 @@ public class TryParseTests
 	public void TryParse_Long_Succeeds(string text)
 	{
 		var expression = new ExtendedExpression($"tryParse('long', '{text}', 'outputVariable')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -188,7 +188,7 @@ public class TryParseTests
 	public void TryParse_ULong_Succeeds(string text)
 	{
 		var expression = new ExtendedExpression($"tryParse('ulong', '{text}', 'outputVariable')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -198,7 +198,7 @@ public class TryParseTests
 	public void TryParse_UInt_Succeeds(string text)
 	{
 		var expression = new ExtendedExpression($"tryParse('uint', '{text}', 'outputVariable')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -210,7 +210,7 @@ public class TryParseTests
 	public void TryParse_Double_Succeeds(string text)
 	{
 		var expression = new ExtendedExpression($"tryParse('double', '{text}', 'outputVariable')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -222,7 +222,7 @@ public class TryParseTests
 	public void TryParse_Float_Succeeds(string text)
 	{
 		var expression = new ExtendedExpression($"tryParse('float', '{text}', 'outputVariable')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -234,7 +234,7 @@ public class TryParseTests
 	public void TryParse_Decimal_Succeeds(string text)
 	{
 		var expression = new ExtendedExpression($"tryParse('decimal', '{text}', 'outputVariable')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -246,7 +246,7 @@ public class TryParseTests
 	public void TryParse_SByte_Succeeds(string text)
 	{
 		var expression = new ExtendedExpression($"tryParse('sbyte', '{text}', 'outputVariable')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -256,7 +256,7 @@ public class TryParseTests
 	public void TryParse_Byte_Succeeds(string text)
 	{
 		var expression = new ExtendedExpression($"tryParse('byte', '{text}', 'outputVariable')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -268,7 +268,7 @@ public class TryParseTests
 	public void TryParse_Short_Succeeds(string text)
 	{
 		var expression = new ExtendedExpression($"tryParse('short', '{text}', 'outputVariable')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -278,7 +278,7 @@ public class TryParseTests
 	public void TryParse_Ushort_Succeeds(string text)
 	{
 		var expression = new ExtendedExpression($"tryParse('ushort', '{text}', 'outputVariable')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -288,7 +288,7 @@ public class TryParseTests
 	public void TryParse_JObject_Succeeds(string text)
 	{
 		var expression = new ExtendedExpression($"tryParse('jObject', '{text}', 'outputVariable')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -298,7 +298,7 @@ public class TryParseTests
 	public void TryParse_JArray_Succeeds(string text)
 	{
 		var expression = new ExtendedExpression($"tryParse('jArray', '{text}', 'outputVariable')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -308,7 +308,7 @@ public class TryParseTests
 	public void TryParse_CapitalJ_JObject_Succeeds(string text)
 	{
 		var expression = new ExtendedExpression($"tryParse('JObject', '{text}', 'outputVariable')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -318,7 +318,7 @@ public class TryParseTests
 	public void TryParse_CapitalJ_JArray_Succeeds(string text)
 	{
 		var expression = new ExtendedExpression($"tryParse('JArray', '{text}', 'outputVariable')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(true);
 	}
 
@@ -327,14 +327,14 @@ public class TryParseTests
 	public void TryParse_JObject_InvalidJson_ReturnsFalse()
 	{
 		var expression = new ExtendedExpression("tryParse('jObject', '{invalid}', 'outputVariable')");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	[Fact]
 	public void TryParse_JArray_InvalidJson_ReturnsFalse()
 	{
 		var expression = new ExtendedExpression("tryParse('jArray', '[invalid]', 'outputVariable')");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	// Test JObject when JSON is actually JArray
@@ -342,7 +342,7 @@ public class TryParseTests
 	public void TryParse_JObject_WhenArray_ReturnsFalse()
 	{
 		var expression = new ExtendedExpression("tryParse('jObject', '[]', 'outputVariable')");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	// Test JArray when JSON is actually JObject
@@ -350,7 +350,7 @@ public class TryParseTests
 	public void TryParse_JArray_WhenObject_ReturnsFalse()
 	{
 		var expression = new ExtendedExpression("tryParse('jArray', '{}', 'outputVariable')");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	// Test unsupported type
@@ -358,7 +358,7 @@ public class TryParseTests
 	public void TryParse_UnsupportedType_ThrowsException()
 	{
 		var expression = new ExtendedExpression("tryParse('unsupportedType', '1', 'outputVariable')");
-		expression.Invoking(e => e.Evaluate())
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<Exception>(); // Throws FormatException but wraps IndexOutOfRangeException
 	}
 
@@ -367,35 +367,35 @@ public class TryParseTests
 	public void TryParse_Int_MaxValue_Succeeds()
 	{
 		var expression = new ExtendedExpression("tryParse('int', '2147483647', 'outputVariable')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void TryParse_Int_MinValue_Succeeds()
 	{
 		var expression = new ExtendedExpression("tryParse('int', '-2147483648', 'outputVariable')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void TryParse_Int_Overflow_ReturnsFalse()
 	{
 		var expression = new ExtendedExpression("tryParse('int', '2147483648', 'outputVariable')");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	[Fact]
 	public void TryParse_Byte_MaxValue_Succeeds()
 	{
 		var expression = new ExtendedExpression("tryParse('byte', '255', 'outputVariable')");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
 	public void TryParse_Byte_Overflow_ReturnsFalse()
 	{
 		var expression = new ExtendedExpression("tryParse('byte', '256', 'outputVariable')");
-		expression.Evaluate().Should().Be(false);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(false);
 	}
 
 	// Test retrieval of parsed values
@@ -403,14 +403,14 @@ public class TryParseTests
 	public void TryParse_AndRetrieve_Int_Works()
 	{
 		var expression = new ExtendedExpression("if(tryParse('int', '42', 'myVar'), retrieve('myVar'), -1)");
-		expression.Evaluate().Should().Be(42);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(42);
 	}
 
 	[Fact]
 	public void TryParse_AndRetrieve_Bool_Works()
 	{
 		var expression = new ExtendedExpression("if(tryParse('bool', 'true', 'myVar'), retrieve('myVar'), false)");
-		expression.Evaluate().Should().Be(true);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(true);
 	}
 
 	[Fact]
@@ -418,6 +418,6 @@ public class TryParseTests
 	{
 		var guid = "fa2e60e8-dd1e-4cbb-b53c-e69c63f14866";
 		var expression = new ExtendedExpression($"if(tryParse('Guid', '{guid}', 'myVar'), retrieve('myVar'), null)");
-		expression.Evaluate().Should().Be(Guid.Parse(guid));
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(Guid.Parse(guid));
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/TryTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/TryTests.cs
@@ -4,13 +4,13 @@ public class TryTests
 {
 	[Fact]
 	public void Try_ToFewParameters_Fails()
-		=> new ExtendedExpression("try()").Invoking(y => y.Evaluate())
+		=> new ExtendedExpression("try()").Invoking(y => y.Evaluate(TestContext.Current.CancellationToken))
 			.Should().Throw<FormatException>()
 			.WithMessage("try: At least 1 parameter required.");
 
 	[Fact]
 	public void Try_ToManyParameters_Fails()
-	  => new ExtendedExpression("try(throw('Woo'), 2, 3)").Invoking(y => y.Evaluate())
+	  => new ExtendedExpression("try(throw('Woo'), 2, 3)").Invoking(y => y.Evaluate(TestContext.Current.CancellationToken))
 		  .Should().Throw<FormatException>()
 		  .WithMessage("try: No more than 2 parameters permitted.");
 
@@ -25,7 +25,7 @@ public class TryTests
 	public void Try_SimpleNoThrow_Succeeds(string parameters, object? expectedValue)
 	{
 		var result = new ExtendedExpression($"try({parameters})")
-			.Evaluate();
+			.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(expectedValue);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/TypeHelperTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/TypeHelperTests.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using PanoramicData.NCalcExtensions.Helpers;
+using TypeHelper = PanoramicData.NCalcExtensions.Helpers.TypeHelper;
 
 namespace PanoramicData.NCalcExtensions.Test;
 

--- a/PanoramicData.NCalcExtensions.Test/TypeMixingTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/TypeMixingTests.cs
@@ -6,7 +6,7 @@ public class TypeMixingTests
 	public void TextPlusInteger_Fails()
 	{
 		var expression = new ExtendedExpression($"'a' + 1");
-		((Action)(() => expression.Evaluate()))
+		((Action)(() => expression.Evaluate(TestContext.Current.CancellationToken)))
 			.Should()
 			.Throw<FormatException>();
 	}
@@ -15,7 +15,7 @@ public class TypeMixingTests
 	public void TextMinusInteger_Fails()
 	{
 		var expression = new ExtendedExpression($"'a' - 1");
-		((Action)(() => expression.Evaluate()))
+		((Action)(() => expression.Evaluate(TestContext.Current.CancellationToken)))
 			.Should()
 			.Throw<FormatException>();
 	}
@@ -24,7 +24,7 @@ public class TypeMixingTests
 	public void TextPlusFloat_Fails()
 	{
 		var expression = new ExtendedExpression($"'a' + 1.5");
-		((Action)(() => expression.Evaluate()))
+		((Action)(() => expression.Evaluate(TestContext.Current.CancellationToken)))
 			.Should()
 			.Throw<FormatException>();
 	}
@@ -33,7 +33,7 @@ public class TypeMixingTests
 	public void TextMinusFloat_Fails()
 	{
 		var expression = new ExtendedExpression($"'a' - 1.5");
-		((Action)(() => expression.Evaluate()))
+		((Action)(() => expression.Evaluate(TestContext.Current.CancellationToken)))
 			.Should()
 			.Throw<FormatException>();
 	}
@@ -42,7 +42,7 @@ public class TypeMixingTests
 	public void IntegerPlusText_Fails()
 	{
 		var expression = new ExtendedExpression($"1 + 'a'");
-		((Action)(() => expression.Evaluate()))
+		((Action)(() => expression.Evaluate(TestContext.Current.CancellationToken)))
 			.Should()
 			.Throw<FormatException>();
 	}
@@ -60,7 +60,7 @@ public class TypeMixingTests
 	{
 		var expression = new ExtendedExpression($"'a' + value");
 		expression.Parameters["value"] = Activator.CreateInstance(type);
-		((Action)(() => expression.Evaluate()))
+		((Action)(() => expression.Evaluate(TestContext.Current.CancellationToken)))
 			.Should()
 			.Throw<FormatException>();
 	}

--- a/PanoramicData.NCalcExtensions.Test/TypeOfTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/TypeOfTests.cs
@@ -10,6 +10,6 @@ public class TypeOfTests
 	public void TypeOf_ReturnsExpected(string? expected, string input)
 	{
 		var expression = new ExtendedExpression($"typeOf({input})");
-		expression.Evaluate().Should().Be(expected);
+		expression.Evaluate(TestContext.Current.CancellationToken).Should().Be(expected);
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/WeekOfYearTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/WeekOfYearTests.cs
@@ -13,7 +13,7 @@ public class WeekOfYearTests : NCalcTest
 	public void Format_WeekOfYear_ReturnsExpected(string dateString, int expectedWeek)
 	{
 		var expression = new ExtendedExpression($"format('{dateString}', 'weekOfYear')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(expectedWeek.ToString(CultureInfo.InvariantCulture));
 	}
 
@@ -28,7 +28,7 @@ public class WeekOfYearTests : NCalcTest
 	public void Format_IsoWeekOfYear_ReturnsExpected(string dateString, int expectedWeek)
 	{
 		var expression = new ExtendedExpression($"format('{dateString}', 'isoWeekOfYear')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().Be(expectedWeek.ToString(CultureInfo.InvariantCulture));
 	}
 
@@ -37,7 +37,7 @@ public class WeekOfYearTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("format(theDateTime, 'weekOfYear')");
 		expression.Parameters["theDateTime"] = new DateTime(2024, 6, 15);
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().NotBeNull();
 		var weekNumber = int.Parse(result.ToString()!, CultureInfo.InvariantCulture);
 		weekNumber.Should().BeGreaterThan(0).And.BeLessThanOrEqualTo(53);
@@ -48,7 +48,7 @@ public class WeekOfYearTests : NCalcTest
 	{
 		var expression = new ExtendedExpression("format(theDateTime, 'isoWeekOfYear')");
 		expression.Parameters["theDateTime"] = new DateTime(2024, 6, 15);
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().NotBeNull();
 		var weekNumber = int.Parse(result.ToString()!, CultureInfo.InvariantCulture);
 		weekNumber.Should().BeGreaterThan(0).And.BeLessThanOrEqualTo(53);
@@ -63,7 +63,7 @@ public class WeekOfYearTests : NCalcTest
 		ArgumentNullException.ThrowIfNull(expectedIsoWeek);
 
 		var expression = new ExtendedExpression($"format('{dateString}', 'isoWeekOfYear')");
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().NotBeNull();
 		var weekNumber = int.Parse(result.ToString()!, CultureInfo.InvariantCulture);
 		var expectedWeekNumber = int.Parse(expectedIsoWeek.Split('-')[1][1..], CultureInfo.InvariantCulture);

--- a/PanoramicData.NCalcExtensions.Test/WhereTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/WhereTests.cs
@@ -9,7 +9,7 @@ public class WhereTests : NCalcTest
 	[InlineData("n % 2 == 0", 2)]
 	public void Where_Succeeds(string expression, int expectedCount)
 		=> new ExtendedExpression($"length(where(list(1, 2, 3, 4, 5), 'n', '{expression}'))")
-		.Evaluate()
+		.Evaluate(TestContext.Current.CancellationToken)
 		.Should()
 		.Be(expectedCount);
 
@@ -29,9 +29,9 @@ where(
 """;
 
 		var expression = new ExtendedExpression(expressionText);
-		Action act = () => expression.Evaluate();
+		Action act = () => expression.Evaluate(TestContext.Current.CancellationToken);
 		act.Should().NotThrow();
-		var result = expression.Evaluate();
+		var result = expression.Evaluate(TestContext.Current.CancellationToken);
 		result.Should().BeOfType<List<object?>>();
 		var list = (List<object?>)result;
 		list.Count.Should().Be(3);
@@ -48,7 +48,7 @@ where(
 	public void Where_EmptyList_ReturnsEmptyList()
 	{
 		var expression = new ExtendedExpression("where(list(), 'n', 'n > 0')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().BeEmpty();
 	}
@@ -57,7 +57,7 @@ where(
 	public void Where_NoneMatch_ReturnsEmptyList()
 	{
 		var expression = new ExtendedExpression("where(list(1, 2, 3), 'n', 'n > 10')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().BeEmpty();
 	}
@@ -66,7 +66,7 @@ where(
 	public void Where_AllMatch_ReturnsAllItems()
 	{
 		var expression = new ExtendedExpression("where(list(1, 2, 3), 'n', 'n > 0')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 	}
@@ -75,7 +75,7 @@ where(
 	public void Where_WithNulls_HandlesCorrectly()
 	{
 		var expression = new ExtendedExpression("where(list(1, null, 3, null, 5), 'n', 'n != null')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().HaveCount(3);
 	}
@@ -85,7 +85,7 @@ where(
 	public void Where_LambdaReturnsFalse_FiltersOut()
 	{
 		var expression = new ExtendedExpression("where(list(1, 2, 3), 'n', 'false')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().BeEmpty();
 	}
@@ -94,7 +94,7 @@ where(
 	public void Where_LambdaReturnsNull_FiltersOut()
 	{
 		var expression = new ExtendedExpression("where(list(1, 2, 3), 'n', 'null')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().BeEmpty();
 	}
@@ -103,7 +103,7 @@ where(
 	public void Where_LambdaReturnsNonBoolean_FiltersOut()
 	{
 		var expression = new ExtendedExpression("where(list(1, 2, 3), 'n', 'n')");
-		var result = expression.Evaluate() as List<object?>;
+		var result = expression.Evaluate(TestContext.Current.CancellationToken) as List<object?>;
 		result.Should().NotBeNull();
 		result.Should().BeEmpty();
 	}
@@ -113,7 +113,7 @@ where(
 	public void Where_NullFirstParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("where(null, 'n', 'n > 0')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*First*parameter must be an IEnumerable*");
 	}
 
@@ -121,7 +121,7 @@ where(
 	public void Where_NonEnumerableFirstParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("where(123, 'n', 'n > 0')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*First*parameter must be an IEnumerable*");
 	}
 
@@ -129,7 +129,7 @@ where(
 	public void Where_StringFirstParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("where('not a list', 'n', 'n > 0')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*First*parameter must be an IEnumerable*");
 	}
 
@@ -138,7 +138,7 @@ where(
 	public void Where_NullSecondParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("where(list(1, 2, 3), null, 'n > 0')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*Second*parameter must be a string*");
 	}
 
@@ -146,7 +146,7 @@ where(
 	public void Where_NonStringSecondParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("where(list(1, 2, 3), 123, 'n > 0')");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*Second*parameter must be a string*");
 	}
 
@@ -155,7 +155,7 @@ where(
 	public void Where_NullThirdParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("where(list(1, 2, 3), 'n', null)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*Third*parameter must be a string*");
 	}
 
@@ -163,7 +163,7 @@ where(
 	public void Where_NonStringThirdParameter_ThrowsException()
 	{
 		var expression = new ExtendedExpression("where(list(1, 2, 3), 'n', 456)");
-		expression.Invoking(e => e.Evaluate()).Should().ThrowExactly<FormatException>()
+		expression.Invoking(e => e.Evaluate(TestContext.Current.CancellationToken)).Should().ThrowExactly<FormatException>()
 			.WithMessage("*Third*parameter must be a string*");
 	}
 }

--- a/PanoramicData.NCalcExtensions.Test/xunit.runner.json
+++ b/PanoramicData.NCalcExtensions.Test/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+	"culture": "invariant"
+}

--- a/PanoramicData.NCalcExtensions/PanoramicData.NCalcExtensions.csproj
+++ b/PanoramicData.NCalcExtensions/PanoramicData.NCalcExtensions.csproj
@@ -45,7 +45,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="NCalcSync" Version="5.8.0" />
+		<PackageReference Include="NCalcSync" Version="5.11.0" />
 		<PackageReference Include="Nerdbank.GitVersioning" Version="3.9.50">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This resolves the issue where, within a .NET 10 project, inheriting a class from ExtendedExpression and adding custom functions would otherwise result in the following exception:

System.MissingMethodException: Method not found: 'System.Object NCalc.Expression.Evaluate()'.

This exception occurred because NCalc version 5.8 does not support .NET 10.