### PR TITLE
Preserve the original exception when Is* functions rethrow as FormatException (fixes #65)

### DIFF
--- a/PanoramicData.NCalcExtensions.Test/InnerExceptionPreservationTests.cs
+++ b/PanoramicData.NCalcExtensions.Test/InnerExceptionPreservationTests.cs
@@ -1,0 +1,65 @@
+using NCalc.Exceptions;
+
+namespace PanoramicData.NCalcExtensions.Test;
+
+/// <summary>
+/// Issue #65: the Is* predicates convert an unexpected evaluation failure into a <see cref="FormatException"/>.
+/// They must pass the original exception through as <see cref="Exception.InnerException"/>, or the caller has
+/// no way to tell *why* evaluation failed.
+///
+/// <para>
+/// The motivating case: an unbound parameter raises <see cref="NCalcParameterNotDefinedException"/>. Referenced
+/// directly, a caller can catch that type. Referenced from inside one of these functions it became a bare
+/// <see cref="FormatException"/> with a null InnerException, leaving message text as the only signal - which is
+/// indistinguishable from a genuine formatting failure such as parsing a non-numeric string.
+/// </para>
+/// </summary>
+public class InnerExceptionPreservationTests
+{
+	private const string UnboundParameterName = "someUnboundField";
+
+	public static TheoryData<string> IsFunctions => new(
+		"isNullOrWhiteSpace",
+		"isNullOrEmpty",
+		"isNull",
+		"isNaN",
+		"isInfinite");
+
+	/// <summary>
+	/// The type of the original failure must survive the conversion.
+	/// </summary>
+	[Theory]
+	[MemberData(nameof(IsFunctions))]
+	public void IsFunction_WhenTheParameterIsUnbound_PreservesTheOriginalExceptionAsInner(string functionName)
+		=> new ExtendedExpression($"{functionName}({UnboundParameterName})")
+			.Invoking(x => x.Evaluate())
+			.Should()
+			.Throw<FormatException>()
+			.WithInnerExceptionExactly<NCalcParameterNotDefinedException>();
+
+	/// <summary>
+	/// The outer type and message are deliberately unchanged, so anything already catching FormatException
+	/// or matching on its text keeps working. This is what makes the fix safe to take.
+	/// </summary>
+	[Theory]
+	[MemberData(nameof(IsFunctions))]
+	public void IsFunction_WhenTheParameterIsUnbound_KeepsTheOuterTypeAndMessage(string functionName)
+		=> new ExtendedExpression($"{functionName}({UnboundParameterName})")
+			.Invoking(x => x.Evaluate())
+			.Should()
+			.Throw<FormatException>()
+			.WithMessage($"Parameter {UnboundParameterName} not defined.");
+
+	/// <summary>
+	/// The wrong-parameter-count guard throws FormatException directly rather than converting something else,
+	/// so it legitimately has no inner exception. Pinned so a later refactor does not quietly start wrapping it.
+	/// </summary>
+	[Fact]
+	public void IsFunction_WithTooManyParameters_ThrowsWithoutAnInnerException()
+		=> new ExtendedExpression("isNullOrWhiteSpace('a', 'b')")
+			.Invoking(x => x.Evaluate())
+			.Should()
+			.Throw<FormatException>()
+			.WithMessage("isNullOrWhiteSpace() requires one parameter.")
+			.And.InnerException.Should().BeNull();
+}

--- a/PanoramicData.NCalcExtensions/Extensions/IsInfinite.cs
+++ b/PanoramicData.NCalcExtensions/Extensions/IsInfinite.cs
@@ -33,7 +33,7 @@ internal static class IsInfinite
 		}
 		catch (Exception e) when (e is not (NCalcExtensionsException or FormatException))
 		{
-			throw new FormatException(e.Message);
+			throw new FormatException(e.Message, e);
 		}
 	}
 }

--- a/PanoramicData.NCalcExtensions/Extensions/IsNaN.cs
+++ b/PanoramicData.NCalcExtensions/Extensions/IsNaN.cs
@@ -36,7 +36,7 @@ internal static class IsNaN
 		}
 		catch (Exception e) when (e is not (NCalcExtensionsException or FormatException))
 		{
-			throw new FormatException(e.Message);
+			throw new FormatException(e.Message, e);
 		}
 	}
 }

--- a/PanoramicData.NCalcExtensions/Extensions/IsNull.cs
+++ b/PanoramicData.NCalcExtensions/Extensions/IsNull.cs
@@ -37,7 +37,7 @@ internal static class IsNull
 		}
 		catch (Exception e) when (e is not (NCalcExtensionsException or FormatException))
 		{
-			throw new FormatException(e.Message);
+			throw new FormatException(e.Message, e);
 		}
 	}
 }

--- a/PanoramicData.NCalcExtensions/Extensions/IsNullOrEmpty.cs
+++ b/PanoramicData.NCalcExtensions/Extensions/IsNullOrEmpty.cs
@@ -33,7 +33,7 @@ internal static class IsNullOrEmpty
 		}
 		catch (Exception e) when (e is not (NCalcExtensionsException or FormatException))
 		{
-			throw new FormatException(e.Message);
+			throw new FormatException(e.Message, e);
 		}
 	}
 }

--- a/PanoramicData.NCalcExtensions/Extensions/IsNullOrWhiteSpace.cs
+++ b/PanoramicData.NCalcExtensions/Extensions/IsNullOrWhiteSpace.cs
@@ -33,7 +33,7 @@ internal static class IsNullOrWhiteSpace
 		}
 		catch (Exception e) when (e is not (NCalcExtensionsException or FormatException))
 		{
-			throw new FormatException(e.Message);
+			throw new FormatException(e.Message, e);
 		}
 	}
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@ Keep upcoming changes under `## Unreleased`.
 creates a fresh `## Unreleased` section, commits the file, and then calls `Publish.ps1`.
 
 ## Unreleased
+- Fixed `isNull()`, `isNullOrEmpty()`, `isNullOrWhiteSpace()`, `isNaN()` and `isInfinite()` discarding the original exception when converting an unexpected evaluation failure into a `FormatException`. The original is now passed through as `InnerException`, so a caller can distinguish an unbound parameter (`NCalcParameterNotDefinedException`) from a genuine formatting failure such as parsing a non-numeric string. The exception type and message are unchanged, so existing callers are unaffected.
 
 ## 6.1.3 - 2026-08-07
 - Added `dateTimeIsInWindow('CRON', durationSeconds, 'TimeZone')` returning whether the current instant is within a recurring window that starts at each CRON fire time and lasts `durationSeconds` (start inclusive, end exclusive). Supports 5-field CRON expressions, or 6 fields when including seconds; `'?'` is accepted as `'*'`. The optional timezone (IANA or Windows form) defaults to UTC. Honours the injectable `TimeProvider` for deterministic evaluation. Adds a dependency on Cronos.


### PR DESCRIPTION
Fixes #65.

## What

One word per site, in the five `Is*` predicates:

```diff
-throw new FormatException(e.Message);
+throw new FormatException(e.Message, e);
```

`IsInfinite`, `IsNaN`, `IsNull`, `IsNullOrEmpty`, `IsNullOrWhiteSpace`.

## Why

These functions convert an unexpected evaluation failure into a `FormatException` but passed only `e.Message`, discarding `e`. The caller was left with no way to tell *why* evaluation failed.

An unbound parameter raises `NCalcParameterNotDefinedException`. Referenced directly, a caller can catch that type. Referenced from inside one of these functions it arrived as a bare `FormatException` with a null `InnerException`, which is indistinguishable from a genuine formatting failure such as `parseInt('abc')` - also a `FormatException`. Consumers were pushed into string-matching the message to tell the two apart, which breaks silently on any upstream wording change.

Magic Suite hit exactly this in ConnectMagic (MS-25506): a mapping condition of the shape `!isNullOrWhiteSpace(toString(someField))` needed to be treated as "condition not met" rather than failing the sync action, and because the type was unrecoverable the guard had to match on message shape instead.

## Is this a breaking change?

**No - it is strictly additive.** The outer exception type and message are unchanged, so anything already catching `FormatException`, or matching on its text, behaves exactly as before. The only difference is that `InnerException` goes from `null` to the real cause.

That claim is evidenced rather than asserted. With the source change reverted and the new tests left in place:

- the **5** assertions that `InnerException` is preserved **fail**
- the **6** assertions that the outer type and message are unchanged **still pass**

So the tests demonstrate the fix adds information without altering anything observable to an existing caller.

## Tests

New `InnerExceptionPreservationTests` - 11 tests across all five functions:

- the original exception is preserved as `InnerException` (`NCalcParameterNotDefinedException`)
- the outer type and message are unchanged
- the wrong-parameter-count guard, which throws `FormatException` directly rather than converting anything, still correctly has **no** inner exception - pinned so a later refactor cannot quietly start wrapping it

| | Tests | Failed |
|---|---|---|
| `main` before | 2165 | 0 |
| this branch | 2176 | 0 |

The +11 is exactly the new tests. No existing test changed behaviour.

## Release notes

Added under `## Unreleased` in `RELEASE_NOTES.md`, per the file's own convention. No version bumped by hand - NBGV stamps it and `PublishWithReleaseNote.ps1` rolls the section at publish time.

## Possible follow-up, deliberately not done here

Whether `NCalcParameterNotDefinedException` should propagate unchanged rather than being converted to `FormatException` at all - "a parameter was not bound" is arguably not a formatting error. That *would* be a breaking change, so it deserves its own decision and its own PR.
